### PR TITLE
add sticky position for table header instead specific column

### DIFF
--- a/src/webapp/reports/autogenerated-forms/DataElementItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataElementItem.tsx
@@ -8,6 +8,7 @@ import DataEntryItem, { DataEntryItemProps } from "./DataEntryItem";
 import { DataValue } from "../../../domain/common/entities/DataValue";
 import { Row } from "./GridWithTotalsViewModel";
 import { isDev } from "../../..";
+import { Maybe } from "../../../utils/ts-utils";
 
 export interface DataElementItemProps {
     dataElement: DataElement;
@@ -21,6 +22,7 @@ export interface DataElementItemProps {
     rowDataElements?: DataElement[];
     columnDataElements?: DataElement[];
     rows?: Row[];
+    rowName?: string;
 }
 
 export const DataElementItem: React.FC<DataElementItemProps> = React.memo(props => {
@@ -36,6 +38,7 @@ export const DataElementItem: React.FC<DataElementItemProps> = React.memo(props 
         rowDataElements,
         columnDataElements,
         rows,
+        rowName,
     } = props;
 
     const classes = useStyles();
@@ -57,9 +60,33 @@ export const DataElementItem: React.FC<DataElementItemProps> = React.memo(props 
         }
     };
 
+    const onClick = (dataElement: DataElement, rowName: Maybe<string>) => {
+        if (!isDev && rowName) {
+            const topBarDeNameEl = window.document.querySelector("#currentDataElement");
+            if (topBarDeNameEl) {
+                topBarDeNameEl.textContent = `${rowName} ${dataElement.name}`;
+            }
+        }
+    };
+
+    const onBlur = () => {
+        console.log("Leaving");
+        if (!isDev) {
+            const topBarDeNameEl = window.document.querySelector("#currentDataElement");
+            if (topBarDeNameEl) {
+                topBarDeNameEl.textContent = "No Data Element Selected";
+            }
+        }
+    };
+
     return !noComment ? (
         <div id={elId} className={classes.valueWrapper}>
-            <div className={`${classes.valueInput} sourcetype`} id={auditId}>
+            <div
+                onClick={() => onClick(dataElement, rowName)}
+                onBlur={() => onBlur()}
+                className={`${classes.valueInput} sourcetype`}
+                id={auditId}
+            >
                 <DataEntryItem
                     dataElement={dataElement}
                     dataFormInfo={dataFormInfo}
@@ -78,7 +105,13 @@ export const DataElementItem: React.FC<DataElementItemProps> = React.memo(props 
         </div>
     ) : (
         <div id={elId} className={classes.valueWrapper}>
-            <div onDoubleClick={() => onDoubleClick()} className={`${classes.valueInput} entryfield2`} id={auditId}>
+            <div
+                onClick={() => onClick(dataElement, rowName)}
+                onBlur={() => onBlur()}
+                onDoubleClick={() => onDoubleClick()}
+                className={`${classes.valueInput} entryfield2`}
+                id={auditId}
+            >
                 <DataEntryItem
                     dataElement={dataElement}
                     dataFormInfo={dataFormInfo}

--- a/src/webapp/reports/autogenerated-forms/GridWithCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCombos.tsx
@@ -28,7 +28,7 @@ const GridWithCombos: React.FC<GridWithCombosProps> = props => {
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo}>
             <DataTable className={classes.table} layout="fixed" width="initial">
-                <TableHead>
+                <TableHead className={classes.tableHeader}>
                     <DataTableRow>
                         {grid.parentColumns.length > 0 && <DataTableColumnHeader></DataTableColumnHeader>}
                         {grid.parentColumns.map(column => {
@@ -110,6 +110,7 @@ const useStyles = makeStyles({
             alignItems: "center",
         },
     },
+    tableHeader: { position: "sticky", top: 0, zIndex: 2 },
 });
 
 export default React.memo(GridWithCombos);

--- a/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
@@ -22,7 +22,6 @@ export interface GridWithTotalsProps {
 }
 
 const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
-    const topValue = "0";
     const { dataFormInfo, section } = props;
 
     const grid = React.useMemo(
@@ -36,7 +35,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo}>
             <DataTable className={classes.table} layout="fixed" width="initial">
-                <TableHead>
+                <TableHead className={classes.tableHeader}>
                     <DataTableRow>
                         <DataTableColumnHeader></DataTableColumnHeader>
                         <DataTableColumnHeader></DataTableColumnHeader>
@@ -59,34 +58,22 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                 <span className={classes.header}>#</span>{" "}
                             </DataTableColumnHeader>
                         ) : (
-                            <DataTableColumnHeader fixed top={topValue}></DataTableColumnHeader>
+                            <DataTableColumnHeader></DataTableColumnHeader>
                         )}
 
                         {fistSection ? (
-                            <DataTableColumnHeader
-                                className={classes.columnWidth}
-                                fixed
-                                top={topValue}
-                                key={`column-Total`}
-                            >
+                            <DataTableColumnHeader className={classes.columnWidth} key={`column-Total`}>
                                 <span>Total</span>
                             </DataTableColumnHeader>
                         ) : null}
 
                         {grid.columns.map(column =>
                             column.deName && column.cocName ? (
-                                <DataTableColumnHeader
-                                    fixed
-                                    top={topValue}
-                                    key={`column-${column.name}`}
-                                    className={classes.columnWidth}
-                                >
+                                <DataTableColumnHeader key={`column-${column.name}`} className={classes.columnWidth}>
                                     <span>{column.cocName}</span>
                                 </DataTableColumnHeader>
                             ) : (
                                 <DataTableColumnHeader
-                                    fixed
-                                    top={topValue}
                                     key={`column-${column.name}`}
                                     className={column.name === "Source Type" ? classes.source : classes.columnWidth}
                                 >
@@ -171,6 +158,7 @@ const useStyles = makeStyles({
             alignItems: "center",
         },
     },
+    tableHeader: { position: "sticky", top: 0, zIndex: 2 },
 });
 
 export default React.memo(GridWithTotals);

--- a/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
@@ -131,6 +131,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                                 columnTotal={item.columnTotal}
                                                 rowDataElements={row.rowDataElements}
                                                 columnDataElements={item.columnDataElements}
+                                                rowName={row.name}
                                             />
                                         </DataTableCell>
                                     ) : (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/862khmnxc

### :memo: Implementation

- Adding the sticky position to the whole TableHeader component instead an specific column.

### :video_camera: Screenshots/Screen capture

[autogenforms_fixed_columns.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/aed77ace-beda-44f4-ad9f-d43730ca3324)

### :fire: Notes to the tester

Run `yarn build-autogenerated-forms` to generate the custom form.