### PR TITLE
remove double scroll for sections without fixed headers

### DIFF
--- a/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
@@ -62,7 +62,7 @@ const DataTableSection: React.FC<DataTableProps> = React.memo(props => {
 });
 
 const useStyles = makeStyles({
-    wrapper: { margin: 10, border: "1px solid black", overflow: "auto", maxHeight: "100vh" },
+    wrapper: { margin: 10, border: "1px solid black" },
     toggleWrapper: { margin: 10 },
     toggleTitle: { marginBottom: 10 },
     title: { textAlign: "center", margin: 0, padding: "1em" },

--- a/src/webapp/reports/autogenerated-forms/GridWithCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCombos.tsx
@@ -14,6 +14,7 @@ import { Section } from "../../../domain/common/entities/DataForm";
 import { DataElementItem } from "./DataElementItem";
 import { makeStyles } from "@material-ui/core";
 import DataTableSection from "./DataTableSection";
+import { fixHeaderClasses } from "./datatables/CustomDataTables";
 
 export interface GridWithCombosProps {
     dataFormInfo: DataFormInfo;
@@ -27,73 +28,77 @@ const GridWithCombos: React.FC<GridWithCombosProps> = props => {
 
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo}>
-            <DataTable className={classes.table} layout="fixed" width="initial">
-                <TableHead className={classes.tableHeader}>
-                    <DataTableRow>
-                        {grid.parentColumns.length > 0 && <DataTableColumnHeader></DataTableColumnHeader>}
-                        {grid.parentColumns.map(column => {
-                            return (
-                                <DataTableColumnHeader
-                                    key={column.name}
-                                    className={classes.centerSpan}
-                                    colSpan={String(column.colSpan)}
-                                >
-                                    <span>{column.name}</span>
-                                </DataTableColumnHeader>
-                            );
-                        })}
-                    </DataTableRow>
-
-                    <DataTableRow>
-                        {grid.useIndexes ? (
-                            <DataTableColumnHeader width="30px">
-                                <span className={classes.header}>#</span>{" "}
-                            </DataTableColumnHeader>
-                        ) : (
-                            <DataTableColumnHeader fixed top="0"></DataTableColumnHeader>
-                        )}
-
-                        {grid.columns.map(column => (
-                            <DataTableColumnHeader
-                                fixed
-                                top="0"
-                                key={`column-${column.name}`}
-                                className={
-                                    column.name === "Source type for HWF - (Inputs & Outputs)"
-                                        ? classes.source
-                                        : classes.columnWidth
-                                }
-                            >
-                                <span>{column.cocName}</span>
-                            </DataTableColumnHeader>
-                        ))}
-                    </DataTableRow>
-                </TableHead>
-
-                <TableBody>
-                    {grid.rows.map((row, idx) => (
-                        <DataTableRow key={`policy-${row.name}`}>
-                            <DataTableCell className={classes.td}>
-                                <span>{grid.useIndexes ? (idx + 1).toString() : row.name}</span>
-                            </DataTableCell>
-
-                            {row.items.map((item, idx) =>
-                                item.dataElement ? (
-                                    <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
-                                        <DataElementItem
-                                            dataElement={item.dataElement}
-                                            dataFormInfo={dataFormInfo}
-                                            noComment={item.column.name !== "Source type for HWF - (Inputs & Outputs)"}
-                                        />
-                                    </DataTableCell>
-                                ) : (
-                                    <DataTableCell key={`cell-${idx}`}></DataTableCell>
-                                )
-                            )}
+            <div className={classes.fixedHeaders}>
+                <DataTable className={classes.table} layout="fixed" width="initial">
+                    <TableHead className={classes.tableHeader}>
+                        <DataTableRow>
+                            {grid.parentColumns.length > 0 && <DataTableColumnHeader></DataTableColumnHeader>}
+                            {grid.parentColumns.map(column => {
+                                return (
+                                    <DataTableColumnHeader
+                                        key={column.name}
+                                        className={classes.centerSpan}
+                                        colSpan={String(column.colSpan)}
+                                    >
+                                        <span>{column.name}</span>
+                                    </DataTableColumnHeader>
+                                );
+                            })}
                         </DataTableRow>
-                    ))}
-                </TableBody>
-            </DataTable>
+
+                        <DataTableRow>
+                            {grid.useIndexes ? (
+                                <DataTableColumnHeader width="30px">
+                                    <span className={classes.header}>#</span>{" "}
+                                </DataTableColumnHeader>
+                            ) : (
+                                <DataTableColumnHeader fixed top="0"></DataTableColumnHeader>
+                            )}
+
+                            {grid.columns.map(column => (
+                                <DataTableColumnHeader
+                                    fixed
+                                    top="0"
+                                    key={`column-${column.name}`}
+                                    className={
+                                        column.name === "Source type for HWF - (Inputs & Outputs)"
+                                            ? classes.source
+                                            : classes.columnWidth
+                                    }
+                                >
+                                    <span>{column.cocName}</span>
+                                </DataTableColumnHeader>
+                            ))}
+                        </DataTableRow>
+                    </TableHead>
+
+                    <TableBody>
+                        {grid.rows.map((row, idx) => (
+                            <DataTableRow key={`policy-${row.name}`}>
+                                <DataTableCell className={classes.td}>
+                                    <span>{grid.useIndexes ? (idx + 1).toString() : row.name}</span>
+                                </DataTableCell>
+
+                                {row.items.map((item, idx) =>
+                                    item.dataElement ? (
+                                        <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
+                                            <DataElementItem
+                                                dataElement={item.dataElement}
+                                                dataFormInfo={dataFormInfo}
+                                                noComment={
+                                                    item.column.name !== "Source type for HWF - (Inputs & Outputs)"
+                                                }
+                                            />
+                                        </DataTableCell>
+                                    ) : (
+                                        <DataTableCell key={`cell-${idx}`}></DataTableCell>
+                                    )
+                                )}
+                            </DataTableRow>
+                        ))}
+                    </TableBody>
+                </DataTable>
+            </div>
         </DataTableSection>
     );
 };
@@ -111,6 +116,7 @@ const useStyles = makeStyles({
         },
     },
     tableHeader: { position: "sticky", top: 0, zIndex: 2 },
+    fixedHeaders: fixHeaderClasses.fixedHeaders,
 });
 
 export default React.memo(GridWithCombos);

--- a/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
@@ -15,6 +15,7 @@ import { SectionWithTotals } from "../../../../src/domain/common/entities/DataFo
 import { DataElementItem } from "./DataElementItem";
 import { makeStyles } from "@material-ui/core";
 import DataTableSection from "./DataTableSection";
+import { fixHeaderClasses } from "./datatables/CustomDataTables";
 
 export interface GridWithTotalsProps {
     dataFormInfo: DataFormInfo;
@@ -34,115 +35,124 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
 
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo}>
-            <DataTable className={classes.table} layout="fixed" width="initial">
-                <TableHead className={classes.tableHeader}>
-                    <DataTableRow>
-                        <DataTableColumnHeader></DataTableColumnHeader>
-                        <DataTableColumnHeader></DataTableColumnHeader>
-                        {grid.parentColumns.map(column => {
-                            return (
-                                <DataTableColumnHeader
-                                    key={column.name}
-                                    className={classes.centerSpan}
-                                    colSpan={String(column.colSpan)}
-                                >
-                                    <span>{column.name}</span>
-                                </DataTableColumnHeader>
-                            );
-                        })}
-                        {section.id === "yzMn16Bp1wV" && <DataTableColumnHeader></DataTableColumnHeader>}
-                    </DataTableRow>
-                    <DataTableRow>
-                        {grid.useIndexes ? (
-                            <DataTableColumnHeader width="30px">
-                                <span className={classes.header}>#</span>{" "}
-                            </DataTableColumnHeader>
-                        ) : (
+            <div className={classes.fixedHeaders}>
+                <DataTable className={classes.table} layout="fixed" width="initial">
+                    <TableHead className={classes.tableHeader}>
+                        <DataTableRow>
                             <DataTableColumnHeader></DataTableColumnHeader>
-                        )}
-
-                        {fistSection ? (
-                            <DataTableColumnHeader className={classes.columnWidth} key={`column-Total`}>
-                                <span>Total</span>
-                            </DataTableColumnHeader>
-                        ) : null}
-
-                        {grid.columns.map(column =>
-                            column.deName && column.cocName ? (
-                                <DataTableColumnHeader key={`column-${column.name}`} className={classes.columnWidth}>
-                                    <span>{column.cocName}</span>
+                            <DataTableColumnHeader></DataTableColumnHeader>
+                            {grid.parentColumns.map(column => {
+                                return (
+                                    <DataTableColumnHeader
+                                        key={column.name}
+                                        className={classes.centerSpan}
+                                        colSpan={String(column.colSpan)}
+                                    >
+                                        <span>{column.name}</span>
+                                    </DataTableColumnHeader>
+                                );
+                            })}
+                            {section.id === "yzMn16Bp1wV" && <DataTableColumnHeader></DataTableColumnHeader>}
+                        </DataTableRow>
+                        <DataTableRow>
+                            {grid.useIndexes ? (
+                                <DataTableColumnHeader width="30px">
+                                    <span className={classes.header}>#</span>{" "}
                                 </DataTableColumnHeader>
                             ) : (
-                                <DataTableColumnHeader
-                                    key={`column-${column.name}`}
-                                    className={column.name === "Source Type" ? classes.source : classes.columnWidth}
-                                >
-                                    <span>{column.name}</span>
+                                <DataTableColumnHeader></DataTableColumnHeader>
+                            )}
+
+                            {fistSection ? (
+                                <DataTableColumnHeader className={classes.columnWidth} key={`column-Total`}>
+                                    <span>Total</span>
                                 </DataTableColumnHeader>
-                            )
-                        )}
-                    </DataTableRow>
-                </TableHead>
-
-                <TableBody>
-                    {grid.rows.map((row, idx) => (
-                        <DataTableRow key={`policy-${row.name}`}>
-                            <DataTableCell className={classes.td}>
-                                <p style={{ paddingLeft: row.includePadding ? `${row.includePadding * 10}px` : "0" }}>
-                                    {grid.useIndexes ? (idx + 1).toString() : row.name}
-                                </p>
-                            </DataTableCell>
-
-                            {fistSection && row.total ? (
-                                <DataTableCell key={row.total.id + row.total.cocId}>
-                                    <DataElementItem
-                                        dataElement={row.total}
-                                        dataFormInfo={dataFormInfo}
-                                        manualyDisabled={true}
-                                        noComment={true}
-                                    />
-                                </DataTableCell>
                             ) : null}
 
-                            {row.items.map((item, idx) => {
-                                if (item.column.name === "Source Type") {
-                                    return item.dataElement ? (
-                                        <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
-                                            <DataElementItem
-                                                dataElement={item.dataElement}
-                                                dataFormInfo={dataFormInfo}
-                                                noComment={false}
-                                                columnTotal={item.columnTotal}
-                                                rows={grid.rows}
-                                            />
-                                        </DataTableCell>
-                                    ) : (
-                                        <DataTableCell key={`cell-${idx}`}></DataTableCell>
-                                    );
-                                } else {
-                                    return item.dataElement ? (
-                                        <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
-                                            <DataElementItem
-                                                dataElement={item.dataElement}
-                                                dataFormInfo={dataFormInfo}
-                                                noComment={true}
-                                                manualyDisabled={item.disabled}
-                                                total={row.total}
-                                                columnTotal={item.columnTotal}
-                                                rowDataElements={row.rowDataElements}
-                                                columnDataElements={item.columnDataElements}
-                                                rowName={row.name}
-                                            />
-                                        </DataTableCell>
-                                    ) : (
-                                        <DataTableCell key={`cell-${idx}`}></DataTableCell>
-                                    );
-                                }
-                            })}
+                            {grid.columns.map(column =>
+                                column.deName && column.cocName ? (
+                                    <DataTableColumnHeader
+                                        key={`column-${column.name}`}
+                                        className={classes.columnWidth}
+                                    >
+                                        <span>{column.cocName}</span>
+                                    </DataTableColumnHeader>
+                                ) : (
+                                    <DataTableColumnHeader
+                                        key={`column-${column.name}`}
+                                        className={column.name === "Source Type" ? classes.source : classes.columnWidth}
+                                    >
+                                        <span>{column.name}</span>
+                                    </DataTableColumnHeader>
+                                )
+                            )}
                         </DataTableRow>
-                    ))}
-                </TableBody>
-            </DataTable>
+                    </TableHead>
+
+                    <TableBody>
+                        {grid.rows.map((row, idx) => (
+                            <DataTableRow key={`policy-${row.name}`}>
+                                <DataTableCell className={classes.td}>
+                                    <p
+                                        style={{
+                                            paddingLeft: row.includePadding ? `${row.includePadding * 10}px` : "0",
+                                        }}
+                                    >
+                                        {grid.useIndexes ? (idx + 1).toString() : row.name}
+                                    </p>
+                                </DataTableCell>
+
+                                {fistSection && row.total ? (
+                                    <DataTableCell key={row.total.id + row.total.cocId}>
+                                        <DataElementItem
+                                            dataElement={row.total}
+                                            dataFormInfo={dataFormInfo}
+                                            manualyDisabled={true}
+                                            noComment={true}
+                                        />
+                                    </DataTableCell>
+                                ) : null}
+
+                                {row.items.map((item, idx) => {
+                                    if (item.column.name === "Source Type") {
+                                        return item.dataElement ? (
+                                            <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
+                                                <DataElementItem
+                                                    dataElement={item.dataElement}
+                                                    dataFormInfo={dataFormInfo}
+                                                    noComment={false}
+                                                    columnTotal={item.columnTotal}
+                                                    rows={grid.rows}
+                                                />
+                                            </DataTableCell>
+                                        ) : (
+                                            <DataTableCell key={`cell-${idx}`}></DataTableCell>
+                                        );
+                                    } else {
+                                        return item.dataElement ? (
+                                            <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
+                                                <DataElementItem
+                                                    dataElement={item.dataElement}
+                                                    dataFormInfo={dataFormInfo}
+                                                    noComment={true}
+                                                    manualyDisabled={item.disabled}
+                                                    total={row.total}
+                                                    columnTotal={item.columnTotal}
+                                                    rowDataElements={row.rowDataElements}
+                                                    columnDataElements={item.columnDataElements}
+                                                    rowName={row.name}
+                                                />
+                                            </DataTableCell>
+                                        ) : (
+                                            <DataTableCell key={`cell-${idx}`}></DataTableCell>
+                                        );
+                                    }
+                                })}
+                            </DataTableRow>
+                        ))}
+                    </TableBody>
+                </DataTable>
+            </div>
         </DataTableSection>
     );
 };
@@ -160,6 +170,7 @@ const useStyles = makeStyles({
         },
     },
     tableHeader: { position: "sticky", top: 0, zIndex: 2 },
+    fixedHeaders: fixHeaderClasses.fixedHeaders,
 });
 
 export default React.memo(GridWithTotals);

--- a/src/webapp/reports/autogenerated-forms/datatables/CustomDataTables.ts
+++ b/src/webapp/reports/autogenerated-forms/datatables/CustomDataTables.ts
@@ -12,3 +12,10 @@ export const CustomDataTableColumnHeader = styled(DataTableColumnHeader)<{ backg
 export const CustomDataTableCell = styled(DataTableCell)<{ backgroundColor: string }>`
     background-color: ${props => props.backgroundColor} !important;
 `;
+
+export const fixHeaderClasses = {
+    fixedHeaders: {
+        overflow: "auto",
+        maxHeight: "100vh",
+    },
+};


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693fx6pf

### :memo: Implementation

In order to keep compatibility with other dataSets right now we only support fixed headers for viewTypes: grid with totals and grid with combos.

### :art: Screenshots

### Remove double scroll for grid with cat combos sections
![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/e5b2388a-6357-4472-8885-548b5af29cb5)

### Fixed headers in grid with totals and grid with combos 
![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/94f9f6b7-d6eb-4920-8711-1e430e992d3f)

### :fire: Notes to the tester

Generate the custom form by running 

```bash
yarn build-autogenerated-forms
```