### PR TITLE
add support for disable comments in viewType table

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -132,7 +132,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                             <DataElementItem
                                                 dataElement={dataElement}
                                                 dataFormInfo={dataFormInfo}
-                                                noComment
+                                                noComment={dataElement.disabledComments}
                                             />
                                         </CustomDataTableCell>
                                     ) : (

--- a/src/webapp/reports/autogenerated-forms/GridWithPeriods.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithPeriods.tsx
@@ -131,6 +131,7 @@ const PeriodTable: React.FC<PeriodTableProps> = props => {
                                     <DataTableCell colSpan={grid.periods.length.toString()}>
                                         <DataTableCell>
                                             <DataElementItem
+                                                noComment={row.dataElement.disabledComments}
                                                 dataElement={{ ...row.dataElement, cocId: categoryOptionComboId }}
                                                 dataFormInfo={dataFormInfo}
                                             />
@@ -186,6 +187,7 @@ const DataTableDataElementCell: React.FC<DataTableDataElementCellProps> = props 
             {periods.map(period => (
                 <DataTableCell key={[dataElement.id, period].join("-")}>
                     <DataElementItem
+                        noComment={dataElement.disabledComments}
                         dataElement={{ ...dataElement, cocId: cocId }}
                         dataFormInfo={dataFormInfo}
                         period={period}

--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -53,7 +53,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 <DataElementItem
                                     dataElement={dataElement}
                                     dataFormInfo={dataFormInfo}
-                                    noComment={!dataElement.name.includes("Source type")}
+                                    noComment={dataElement.disabledComments}
                                 />
                             </CustomDataTableCell>
                         </DataTableRow>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693hjfbj

### :memo: Implementation

### :art: Screenshots

![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/2b6569c0-9a65-418b-89bc-25807fd6e81a)

### :fire: Notes to the tester

- Generate the custom form 

```bash
yarn build-autogenerated-forms
```

- Update custom form: https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/dataSetSection/dataSet/CWuqJ3dtQC4/dataEntryForm

- Update json config. in datastore:

By default comments are enabled, but can be disabled.
https://dev.eyeseetea.com/who-dev-238/dhis-web-datastore/index.html#/edit/d2-autogen-forms/0MAL_5

```json
{
  "dataElements": {
      "MAL_ACD_REACTIV_RESPONSE_POLICY_IMPL": {
        "disableComments": true
      },
    }
}
```

- Check the changes in Data Entry: https://dev.eyeseetea.com/who-dev-238/dhis-web-dataentry/index.action