### PR TITLE
disable/hide fields based on the value of a dataElement

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -14,12 +14,7 @@ export class Dhis2DataElement {
 
         const resList = await promiseMap(idGroups, idsGroup =>
             this.api.metadata
-                .get({
-                    dataElements: {
-                        fields: dataElementFields,
-                        filter: { id: { in: idsGroup } },
-                    },
-                })
+                .get({ dataElements: { fields: dataElementFields, filter: { id: { in: idsGroup } } } })
                 .getData()
         );
 
@@ -142,6 +137,7 @@ function getDataElement(dataElement: D2DataElement, config: Dhis2DataStoreDataFo
         options: optionSet
             ? { isMultiple: Boolean(deConfig?.selection?.isMultiple), items: optionSet.options }
             : undefined,
+        rules: [],
     };
 
     switch (valueType) {

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -9,6 +9,7 @@ import { Period } from "../../domain/common/entities/DataValue";
 import { ColumnDescription, Texts } from "../../domain/common/entities/DataForm";
 import { titleVariant } from "../../domain/common/entities/TitleVariant";
 import { SectionStyle, SectionStyleAttrs } from "../../domain/common/entities/SectionStyle";
+import { DataElementRuleOptions } from "../../domain/common/entities/DataElementRule";
 
 interface DataSetConfig {
     texts: Texts;
@@ -131,12 +132,20 @@ const textsCodec = Codec.interface({
     totals: optional(oneOf([string, selector])),
 });
 
+const dataElementRuleCodec = optional(
+    record(
+        oneOf([exactly("visible"), exactly("disabled")]),
+        Codec.interface({ dataElements: array(string), condition: string })
+    )
+);
+
 const DataStoreConfigCodec = Codec.interface({
     categoryCombinations: sectionConfig({
         viewType: optional(oneOf([exactly("name"), exactly("shortName"), exactly("formName")])),
     }),
     dataElements: sectionConfig({
         disableComments: optional(boolean),
+        rules: dataElementRuleCodec,
         selection: optional(
             Codec.interface({
                 optionSet: optional(selector),
@@ -203,7 +212,8 @@ const DataStoreConfigCodec = Codec.interface({
     }),
 });
 
-interface DataElementConfig {
+export interface DataElementConfig {
+    rules?: DataElementRuleOptions;
     disableComments?: boolean;
     selection?: {
         optionSet?: OptionSet;
@@ -550,6 +560,7 @@ export class Dhis2DataStoreDataForm {
 
                 const dataElementConfig: DataElementConfig = {
                     disableComments: config.disableComments,
+                    rules: config.rules,
                     selection: {
                         isMultiple: optionSetSelector?.isMultiple || false,
                         optionSet: optionSet,

--- a/src/domain/common/entities/DataElement.ts
+++ b/src/domain/common/entities/DataElement.ts
@@ -1,5 +1,6 @@
 import { Maybe } from "../../../utils/ts-utils";
 import { Code, Id } from "./Base";
+import { Rule } from "./DataElementRule";
 
 export type DataElement =
     | DataElementBoolean
@@ -25,6 +26,7 @@ interface DataElementBase {
     orgUnit?: Id;
     related: { dataElement: DataElement; value: string } | undefined;
     disabledComments?: boolean;
+    rules: Rule[];
 }
 
 export interface DataElementBoolean extends DataElementBase {

--- a/src/domain/common/entities/DataElementRule.ts
+++ b/src/domain/common/entities/DataElementRule.ts
@@ -1,0 +1,8 @@
+import { Code } from "./Base";
+import { DataElement } from "./DataElement";
+
+export type RuleType = "visible" | "disabled";
+
+export type DataElementRuleOptions = Record<RuleType, { dataElements: Code[]; condition: string }>;
+
+export type Rule = { relatedDataElement: DataElement; type: RuleType; condition: string };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693ejf4y

### :memo: Implementation

We can add `rules` to an specific dataElement and modify the state of other dataElements:

```json
{
  "dataElements": {
    "MAL_NUM_HF_KNOWN_COMM": {
      "rules": {
        "disabled": {
          "dataElements": [
            "MAL_TOTAL_HF_EXPCTD_RPT_EACH_YEAR_COMM",
            "MAL_TOTAL_RPT_RECEVD_COMM"
          ],
          "condition": "false"
        }
      }
    }
  }
}
```

Here we are adding a rule of type `disabled` for the dataElement with code `MAL_NUM_HF_KNOWN_COMM`. A rule has two params: `dataElements` to be affected and a `condition` that will be compare against the value of the current dataElement.

So the above rule is basically doing this: When the value of the dataElement `MAL_NUM_HF_KNOWN_COMM` is equal to false the dataElements `MAL_TOTAL_HF_EXPCTD_RPT_EACH_YEAR_COMM` and `MAL_TOTAL_RPT_RECEVD_COMM` will be disabled.

This way we can add more rule types, like `visible`:

```json
{
  "dataElements": {
    "MAL_NUM_HF_KNOWN_COMM": {
      "rules": {
        "visible": {
          "dataElements": ["MAL_EST_REPORTING_COMPLETENESS_COMM"],
          "condition": "false"
        }
      }
    }
  }
}
```

if the value of `MAL_NUM_HF_KNOWN_COMM` is equal to false hide the `dataElement` with code `MAL_EST_REPORTING_COMPLETENESS_COMM`.

### :art: Screenshots

[autogenforms_rules.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/05918f9b-9e1e-46c1-b87c-964a0bb90894)

### :fire: Notes to the tester

- Generate the custom form 

```bash
yarn build-autogenerated-forms
```

- Update custom form: https://dev.eyeseetea.com/who-dev-238/dhis-web-maintenance/index.html#/edit/dataSetSection/dataSet/CWuqJ3dtQC4/dataEntryForm

- Update json config. in datastore:

https://dev.eyeseetea.com/who-dev-238/dhis-web-datastore/index.html#/edit/d2-autogen-forms/0MAL_5

```json
{
  "dataElements": {
    "MAL_NUM_HF_KNOWN": {
      "rules": {
        "disabled": {
          "dataElements": [
            "MAL_TOTAL_HF_EXPCTD_RPT_EACH_YEAR_PUB",
            "MAL_TOTAL_RPT_RECEVD"
          ],
          "condition": "false"
        },
        "visible": {
          "dataElements": ["MAL_EST_REPORTING_COMPLETENESS_PUB"],
          "condition": "false"
        }
      }
    },
    "MAL_NUM_HF_KNOWN_PRIV": {
      "rules": {
        "disabled": {
          "dataElements": [
            "MAL_TOTAL_HF_EXPCTD_RPT_EACH_YEAR_PRIV",
            "MAL_TOTAL_RPT_RECEVD_PRIV"
          ],
          "condition": "false"
        },
        "visible": {
          "dataElements": ["MAL_EST_REPORTING_COMPLETENESS_PRIV"],
          "condition": "false"
        }
      }
    },
    "MAL_NUM_HF_KNOWN_COMM": {
      "rules": {
        "disabled": {
          "dataElements": [
            "MAL_TOTAL_HF_EXPCTD_RPT_EACH_YEAR_COMM",
            "MAL_TOTAL_RPT_RECEVD_COMM"
          ],
          "condition": "false"
        },
        "visible": {
          "dataElements": ["MAL_EST_REPORTING_COMPLETENESS_COMM"],
          "condition": "false"
        }
      }
    }
  }
}
```

- Check the changes in Data Entry: https://dev.eyeseetea.com/who-dev-238/dhis-web-dataentry/index.action


