### PR TITLE
add multiple toggle configuration

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -6,6 +6,7 @@ import { Rule, RuleType } from "../../domain/common/entities/DataElementRule";
 import { DataForm, defaultTexts, Section, SectionBase } from "../../domain/common/entities/DataForm";
 import { Period } from "../../domain/common/entities/DataValue";
 import { SectionStyle } from "../../domain/common/entities/SectionStyle";
+import { buildToggleMultiple } from "../../domain/common/entities/ToggleMultiple";
 import { DataFormRepository } from "../../domain/common/repositories/DataFormRepository";
 import { D2Api, MetadataPick } from "../../types/d2-api";
 import { Maybe } from "../../utils/ts-utils";
@@ -78,7 +79,6 @@ export class Dhis2DataFormRepository implements DataFormRepository {
 
         return dataSet.sections.map((section): Section => {
             const config = dataSetConfig.sections[section.id];
-
             const base: SectionBase = {
                 id: section.id,
                 name: section.displayName,
@@ -121,6 +121,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                 columnsDescriptions: config?.columnsDescriptions,
                 totals: config?.totals,
                 showRowTotals: section.showRowTotals,
+                toggleMultiple: config?.toggleMultiple ? buildToggleMultiple(config.toggleMultiple, dataElements) : [],
             };
 
             if (!config) return { viewType: "table", ...base };
@@ -214,7 +215,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                     type: ruleType,
                     id: dataElementDetails.id,
                     relatedDataElementId: dataElement.id,
-                    value: dataElementConfig.rules?.disabled.condition || "",
+                    value: dataElementConfig.rules?.disabled?.condition || "",
                 };
             })
             .compact()
@@ -298,7 +299,9 @@ function getSectionBaseWithToggle(
             }
         }
         case "dataElementExternal": {
-            const allDataElements = _(dataElements).map(value => value);
+            const allDataElements = _(dataElements)
+                .map(value => value)
+                .value();
             const toggleDataElement = allDataElements.find(de => de.code === toggle.code);
 
             if (toggleDataElement) {

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -10,6 +10,7 @@ import { ColumnDescription, Texts } from "../../domain/common/entities/DataForm"
 import { titleVariant } from "../../domain/common/entities/TitleVariant";
 import { SectionStyle, SectionStyleAttrs } from "../../domain/common/entities/SectionStyle";
 import { DataElementRuleOptions } from "../../domain/common/entities/DataElementRule";
+import { ToggleMultiple } from "../../domain/common/entities/ToggleMultiple";
 
 interface DataSetConfig {
     texts: Texts;
@@ -40,6 +41,7 @@ interface BaseSectionConfig {
         formula: string;
         texts?: { name: string };
     };
+    toggleMultiple: Maybe<ToggleMultiple[]>;
 }
 
 interface BasicSectionConfig extends BaseSectionConfig {
@@ -209,6 +211,7 @@ const DataStoreConfigCodec = Codec.interface({
                     )
                 ),
                 totals: optional(totalsType),
+                toggleMultiple: optional(array(Codec.interface({ dataElement: string, condition: string }))),
             })
         ),
     }),
@@ -505,6 +508,7 @@ export class Dhis2DataStoreDataForm {
                               formulas: sectionConfig.totals?.formulas,
                           }
                         : undefined,
+                    toggleMultiple: sectionConfig.toggleMultiple,
                 };
 
                 const baseConfig = { ...base, viewType };

--- a/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
+++ b/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
@@ -12,6 +12,7 @@ export class ValidateDatasetRulesUseCase {
 
     async execute(dataSetId: Id, options: ValidateUseCaseOptions): Promise<ValidationResult[]> {
         const rules = await this.getRules(dataSetId, options.cacheKey);
+        if (rules.length === 0) return [];
         const results = await this.ruleRepository.validate(dataSetId, options);
         return this.buildValidationRuleMessages(rules, results);
     }

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -6,6 +6,7 @@ import { DataElement, dataInputPeriodsType } from "./DataElement";
 import { Period } from "./DataValue";
 import { SectionStyle } from "./SectionStyle";
 import { titleVariant } from "./TitleVariant";
+import { DataElementToggle } from "./ToggleMultiple";
 
 export interface DataForm {
     id: Id;
@@ -69,6 +70,7 @@ export interface SectionBase {
         formulas: Record<string, { formula: string }> | undefined;
     };
     showRowTotals: boolean;
+    toggleMultiple: DataElementToggle[];
 }
 
 export interface SectionSimple extends SectionBase {

--- a/src/domain/common/entities/ToggleMultiple.ts
+++ b/src/domain/common/entities/ToggleMultiple.ts
@@ -1,0 +1,34 @@
+import _ from "lodash";
+import { Maybe } from "../../../utils/ts-utils";
+
+import { Code } from "./Base";
+import { DataElement } from "./DataElement";
+
+export type ToggleMultiple = { dataElement: Code; condition: string };
+export type DataElementToggle = { dataElement: DataElement; condition: string };
+
+export function buildToggleMultiple(
+    toggleMultiple: ToggleMultiple[],
+    dataElements: Record<string, DataElement>
+): DataElementToggle[] {
+    const allDataElements = _(dataElements)
+        .map(value => value)
+        .value();
+
+    const toggleDataElements = _(toggleMultiple)
+        .map((toggle): Maybe<DataElementToggle> => {
+            const dataElement = allDataElements.find(dataElement => dataElement.code === toggle.dataElement);
+            if (!dataElement) {
+                console.warn(`Cannot found ${toggle.dataElement} in toggleMultiple config.`);
+                return undefined;
+            }
+            return {
+                condition: toggle.condition,
+                dataElement: dataElement,
+            };
+        })
+        .compact()
+        .value();
+
+    return toggleDataElements;
+}

--- a/src/scripts/translations-mal-wmr.ts
+++ b/src/scripts/translations-mal-wmr.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { ArgumentParser } from "argparse";
 
 import { getCompositionRoot } from "../compositionRoot";

--- a/src/webapp/reports/autogenerated-forms-configurator/schemas/dataSets/section.ts
+++ b/src/webapp/reports/autogenerated-forms-configurator/schemas/dataSets/section.ts
@@ -40,6 +40,16 @@ export const sectionSchema = (constants: string[], deInSectionCodes: string[]) =
                 },
             },
         }),
+        toggleMultiple: {
+            type: "array",
+            items: defaultObjectProperties({
+                type: "object",
+                properties: {
+                    dataElement: { enum: deInSectionCodes },
+                    condition: { type: "string" },
+                },
+            }),
+        },
         titleVariant: {
             enum: ["h1", "h2", "h3", "h4", "h5", "h6"],
         },

--- a/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
@@ -19,11 +19,12 @@ interface DataTableSectionObj {
     titleVariant?: Section["titleVariant"];
     texts: Section["texts"];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
 }
 
 const DataTableSection: React.FC<DataTableProps> = React.memo(props => {
     const { section, children, dataFormInfo, sectionStyles } = props;
-    const { toggle } = section;
+    const { toggle, toggleMultiple } = section;
     const classes = useStyles();
 
     const isSectionOpen = React.useMemo(() => {
@@ -39,9 +40,19 @@ const DataTableSection: React.FC<DataTableProps> = React.memo(props => {
         }
     }, [toggle, dataFormInfo]);
 
+    const isSectionVisible = React.useMemo(() => {
+        const value = toggleMultiple.every(toggle => {
+            const dataValue = dataFormInfo.data.values.getOrEmpty(toggle.dataElement, dataFormInfo);
+            const value = getValueAccordingType(dataValue);
+            return String(value) === toggle.condition;
+        });
+        return value;
+    }, [toggleMultiple, dataFormInfo]);
+
     const titleStyle = section.titleVariant ? `${classes.title} ${classes[section.titleVariant]}` : classes.title;
 
     if (toggle.type === "dataElementExternal" && !isSectionOpen) return null;
+    if (toggleMultiple.length > 0 && !isSectionVisible) return null;
 
     return (
         <div className={classes.wrapper}>

--- a/src/webapp/reports/autogenerated-forms/GridFormViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridFormViewModel.ts
@@ -13,6 +13,7 @@ export interface Grid {
     columns: Column[];
     rows: Row[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     useIndexes: boolean;
     texts: Texts;
     titleVariant: titleVariant;
@@ -130,6 +131,7 @@ export class GridViewModel {
             columns: columns,
             rows: rows,
             toggle: section.toggle,
+            toggleMultiple: section.toggleMultiple,
             texts: section.texts,
             useIndexes: useIndexes,
             titleVariant: section.titleVariant,

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
@@ -12,6 +12,7 @@ export interface Grid {
     columns: Column[];
     rows: Row[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     texts: Texts;
     summary: Maybe<Summary>;
 }
@@ -154,6 +155,7 @@ export class GridWithCatOptionCombosViewModel {
             columns: columns,
             rows: rows,
             toggle: section.toggle,
+            toggleMultiple: section.toggleMultiple,
             texts: section.texts,
             summary: section.totals ? { cellName: section.texts?.totals || "", cells: totals } : undefined,
         };

--- a/src/webapp/reports/autogenerated-forms/GridWithCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCombosViewModel.ts
@@ -8,6 +8,7 @@ export interface Grid {
     columns: Column[];
     rows: Row[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     useIndexes: boolean;
     texts: Texts;
     parentColumns: ParentColumn[];
@@ -109,6 +110,7 @@ export class GridWithCombosViewModel {
             texts: section.texts,
             useIndexes: useIndexes,
             parentColumns: parentColumns.length === columns.length ? [] : parentColumns,
+            toggleMultiple: section.toggleMultiple,
         };
     }
 }

--- a/src/webapp/reports/autogenerated-forms/GridWithPeriodsViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithPeriodsViewModel.ts
@@ -14,6 +14,7 @@ export interface GridWithPeriodsI {
     rows: Row[];
     periods: string[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     texts: Texts;
     tabs: PeriodTab[];
 }
@@ -124,6 +125,7 @@ export class GridWithPeriodsViewModel {
             toggle: section.toggle,
             texts: section.texts,
             tabs: this.buildTabs(section.dataElements),
+            toggleMultiple: section.toggleMultiple,
         };
     }
 

--- a/src/webapp/reports/autogenerated-forms/GridWithSubNationalViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithSubNationalViewModel.ts
@@ -8,6 +8,7 @@ export interface Grid {
     columns: Column[];
     rows: Row[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     useIndexes: boolean;
     texts: Texts;
     parentColumns: ParentColumn[];
@@ -146,6 +147,7 @@ export class GridWithSubNationalViewModel {
             texts: section.texts,
             useIndexes: useIndexes,
             parentColumns,
+            toggleMultiple: section.toggleMultiple,
         };
     }
 }

--- a/src/webapp/reports/autogenerated-forms/GridWithTotalsViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotalsViewModel.ts
@@ -8,6 +8,7 @@ export interface Grid {
     columns: Column[];
     rows: Row[];
     toggle: Section["toggle"];
+    toggleMultiple: Section["toggleMultiple"];
     useIndexes: boolean;
     texts: Texts;
     parentColumns: ParentColumn[];
@@ -186,6 +187,7 @@ export class GridWithTotalsViewModel {
             texts: section.texts,
             useIndexes: useIndexes,
             parentColumns,
+            toggleMultiple: section.toggleMultiple,
         };
     }
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693cf10y

### :memo: Implementation

Because of time constraints and to avoid breaking changes for existing dataSets we're introducing a new configuration for sections:

```json
"MY_SECTION": {
   "viewType": "...",
   ...
  "toggleMultiple": [
    {
      "dataElement": "DE_1",
      "condition": "true"
    },
    {
      "dataElement":   "DE_2",
      "condition": "false"
    }
  ], 
}
```

This means `MY_SECTION` will only be visible when the value of  `DE_1` is equal to `true` AND `DE_2` equal to false

### :art: Screenshots

[autogenforms_multiple_toggle.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/d88846f2-777d-49c8-815a-f0bf793589a9)

### :fire: Notes to the tester

Since @deeonwuli is working in a new feature I did not update the config. in dataStore. If you want to try this please update the config with the content of the file `health_sector_data_multiple_toggle` attached in the issue.