### PR TITLE
feat: add group description to cat option combo viewtype

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -93,7 +93,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
 
                 <TableBody>
                     {grid.rows.map(row => {
-                        const { groupName, rows } = row;
+                        const { groupDescription, groupName, rows } = row;
 
                         return rows.map((row, idx) => (
                             <DataTableRow key={`${groupName}-${idx}`}>
@@ -102,10 +102,10 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                         {idx === 0 && (
                                             <CustomDataTableCell
                                                 backgroundColor={props.section.styles.rows.backgroundColor}
-                                                className={classes.rowTitle}
                                                 rowSpan={rows.length.toString()}
                                             >
-                                                <span>{groupName}</span>
+                                                <span className={classes.rowTitle}>{groupName}</span>
+                                                <Html content={groupDescription} />
                                             </CustomDataTableCell>
                                         )}
 

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
@@ -30,6 +30,7 @@ interface Column {
 
 interface Row {
     groupName: string;
+    groupDescription: Maybe<string>;
     rows: {
         dataElement: DataElement;
         deName: string;
@@ -86,12 +87,18 @@ export class GridWithCatOptionCombosViewModel {
             .flatMap(subsection => subsection.dataElements)
             .uniqBy(de => de.name)
             .groupBy(de => _(de.name.split(separator)).initial().join(" - "))
-            .map((group, groupName) => ({
-                groupName,
-                rows: group.map(de => {
-                    return { dataElement: de, deName: _.last(de.name.split(separator)) ?? "", name: de.name };
-                }),
-            }))
+            .map((group, groupName) => {
+                const firstDeInGroup = _(group).first()?.code || "";
+                const groupDescription = getDescription(section.groupDescriptions, dataFormInfo, firstDeInGroup);
+
+                return {
+                    groupName: groupName,
+                    groupDescription: groupDescription,
+                    rows: group.map(de => {
+                        return { dataElement: de, deName: _.last(de.name.split(separator)) ?? "", name: de.name };
+                    }),
+                };
+            })
             .value();
 
         const columns: Column[] = _.orderBy(


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86942jzn7

### :memo: Implementation
Added the `groupDescriptions` property to the section config for grid-with-cat-options-combo view type
```json
"groupDescriptions": {
  "MAL_CASES_TEST_MICR": {
    "code": "MAL_WMR_CASES_TEST_MICR_DESCRIPTION"
  }
},
```
where `MAL_CASES_TEST_MICR` is the dataElement code of the first data element in the group and `MAL_WMR_CASES_TEST_MICR_DESCRIPTION` is the constant code storing the description text.

### :art: Screenshots
<img width="926" alt="Screenshot 2024-03-22 at 16 19 25" src="https://github.com/EyeSeeTea/d2-autogen-forms/assets/37223065/41db7630-eb42-4df8-9fc5-0e20d46d1a1e">

### :fire: Notes to the tester
```
REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/
```