### PR TITLE
disable pagination to get all constants

### DIFF
--- a/src/data/ConstantD2Repository.ts
+++ b/src/data/ConstantD2Repository.ts
@@ -14,9 +14,7 @@ export class ConstantD2Repository implements ConstantRepository {
 
     async get(): Promise<Constant[]> {
         const { objects: constants } = await this.api.models.constants
-            .get({
-                fields: constantFields,
-            })
+            .get({ fields: constantFields, paging: false })
             .getData();
 
         return constants;

--- a/src/webapp/reports/autogenerated-forms-configurator/schemas/dataSets/section.ts
+++ b/src/webapp/reports/autogenerated-forms-configurator/schemas/dataSets/section.ts
@@ -26,7 +26,10 @@ export const sectionSchema = (
         groupDescriptions: {
             type: "object",
             additionalProperties: {
-                type: textSchema(constantCodes),
+                type: "object",
+                properties: {
+                    code: { enum: constantCodes },
+                },
             },
         },
         disableComments: {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #? 

@MiquelAdell can you help me with the issue for this task?

### :memo: Implementation

- [x] Get all constants to avoid getting only the constants in the first page

### :art: Screenshots

### :fire: Notes to the tester

- add `REACT_APP_REPORT_VARIANT=autogenerated-forms-configurator` to the .env.local file.

- `yarn start`
