### PR TITLE
add calculateTotals to grid with subnationals

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -148,6 +148,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                 case "grid-with-subnational-ous":
                     return {
                         viewType: config.viewType,
+                        calculateTotals: config.calculateTotals,
                         subNationals: config?.subNationalDataset
                             ? _(configDataForm.subNationals)
                                   .filter((sn: SubNational) => sn.parentId === orgUnit)

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -68,6 +68,7 @@ interface GridWithTotalsSectionConfig extends BaseSectionConfig {
 
 interface GridWithSubnationalSectionConfig extends BaseSectionConfig {
     viewType: "grid-with-subnational-ous";
+    calculateTotals: CalculateTotalType;
     subNationalDataset: string;
 }
 
@@ -562,6 +563,7 @@ export class Dhis2DataStoreDataForm {
                         const config = {
                             ...baseConfig,
                             viewType,
+                            calculateTotals: sectionConfig.calculateTotals,
                             subNationalDataset: sectionConfig.subNationalDataset || "",
                         };
                         return [section.id, config] as [typeof section.id, typeof config];

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -99,6 +99,7 @@ export interface SectionWithTotals extends SectionBase {
 
 export interface SectionWithSubnationals extends SectionBase {
     viewType: "grid-with-subnational-ous";
+    calculateTotals: CalculateTotalType;
     subNationals: SubNational[];
 }
 

--- a/src/webapp/reports/autogenerated-forms/GridWithSubNational.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithSubNational.tsx
@@ -55,13 +55,9 @@ const GridWithSubNational: React.FC<GridWithSubNationalProps> = props => {
                                 key={`column-${column.name}`}
                                 fixed
                                 top={topValue}
-                                className={
-                                    column.name === "Source type for HWF - (Inputs & Outputs)"
-                                        ? classes.source
-                                        : classes.columnWidth
-                                }
+                                className={classes.columnWidth}
                             >
-                                <span>{column.cocName}</span>
+                                <span>{column.deName}</span>
                             </DataTableColumnHeader>
                         ))}
                     </DataTableRow>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694b8hz7

### :memo: Implementation

- [x] add support for calculateTotals in viewType `grid-with-subnational-ous`
- [x] fix bug that generates a "Total" column in the header of the table

### :art: Screenshots

Subnational Single Entry
[autogen_form_subnational_single.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/760641d6-350a-499b-af2c-02ce405b130d)

Subnational All Occupations
[autogen_form_subnational_occupations.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/f03286de-0388-44d1-a953-961ee009f786)

### :fire: Notes to the tester

#8694b8hz7

update datastore with configuration attached in issue