### PR TITLE
use translations for name and shortname in category options

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -112,7 +112,7 @@ function getCocOrdered(categoryCombo: D2DataElement["categoryCombo"], config: Dh
         return match
             ? {
                   ...match,
-                  name: categoryOption?.displayName,
+                  name: categoryOption?.displayName || match.name,
                   shortName: categoryOption?.shortName,
                   formName: categoryOption?.formName,
               }

--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -50,7 +50,8 @@ const dataElementFields = {
                 id: true,
                 code: true,
                 name: true,
-                shortName: true,
+                displayName: true,
+                displayShortName: true,
                 displayFormName: true,
             },
         },
@@ -89,7 +90,8 @@ function getCocOrdered(categoryCombo: D2DataElement["categoryCombo"], config: Dh
         .map(c => {
             return c.categoryOptions.flatMap(co => ({
                 name: co.name,
-                shortName: co.shortName,
+                displayName: co.displayName,
+                shortName: co.displayShortName,
                 formName: co.displayFormName,
             }));
         })
@@ -107,7 +109,14 @@ function getCocOrdered(categoryCombo: D2DataElement["categoryCombo"], config: Dh
             return coc.name === cocOrdered;
         });
         const categoryOption = allCategoryOptions.find(c => c.name === match?.name);
-        return match ? { ...match, shortName: categoryOption?.shortName, formName: categoryOption?.formName } : [];
+        return match
+            ? {
+                  ...match,
+                  name: categoryOption?.displayName,
+                  shortName: categoryOption?.shortName,
+                  formName: categoryOption?.formName,
+              }
+            : [];
     });
 
     const keyName = config.categoryCombinationsConfig[categoryCombo.code]?.viewType || "name";

--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -119,8 +119,8 @@ function getCocOrdered(categoryCombo: D2DataElement["categoryCombo"], config: Dh
             : [];
     });
 
-    const keyName = config.categoryCombinationsConfig[categoryCombo.code]?.viewType || "name";
-    return result.map(x => ({ ...x, name: x[keyName] || "" }));
+    const keyName = config.categoryCombinationsConfig[categoryCombo.code]?.viewType || "formName";
+    return result.map(x => ({ ...x, name: x[keyName] || x.name || "" }));
 }
 
 function getDataElement(dataElement: D2DataElement, config: Dhis2DataStoreDataForm): DataElement | null {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694f2q5h

### :memo: Implementation

In `grid-with-combos` by default it was using the `name` attribute. Now it will use the translated field `displayName`. Also you can configure what attribute to use with the following config:

```json
  "categoryCombinations": {
    "MAL_OWNERSHIP": {
      // valid values are: name, shortName and formName
      // it will always use the translated fields for each case: displayName, displayShortName and displayFormName
      "viewType": "formName"
    }
  },
```

### :art: Screenshots

Module 3 in spanish
![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/de648273-8765-4e27-ad7c-072a8ff2b1d3)


### :fire: Notes to the tester

Build the custom form

```bash
yarn build-autogenerated-forms
```

#8694f2q5h