### PR TITLE
fix apply to all logic for source type column

### DIFF
--- a/src/domain/common/usecases/ApplyToAllUseCase.ts
+++ b/src/domain/common/usecases/ApplyToAllUseCase.ts
@@ -25,7 +25,7 @@ export class ApplyToAllUseCase {
                     }
                     return acum;
                 }, "");
-                return suma.length > 0 ? row.items.find(x => x.column.name === "Source Type") : undefined;
+                return suma.length > 0 ? row.items.find(x => x.column.isSourceType) : undefined;
             })
             .compact()
             .value();

--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -165,14 +165,6 @@ const DataEntryItem: React.FC<DataEntryItemProps> = props => {
                 );
             case "TEXT":
                 if (config?.widget === "sourceType" && dataValue.isMultiple) {
-                    const sourceTypeDEs = dataFormInfo.metadata.dataForm.dataElements.flatMap(de => {
-                        if (de.name.endsWith(" - Source Type") && de.id !== dataValue.dataElement.id) {
-                            return { id: de.id, name: de.name };
-                        } else {
-                            return [];
-                        }
-                    });
-
                     return (
                         <SourceTypeWidget
                             dataValue={dataValue}
@@ -181,7 +173,7 @@ const DataEntryItem: React.FC<DataEntryItemProps> = props => {
                             onValueChange={notifyChange}
                             state={state}
                             disabled={disabled}
-                            sourceTypeDEs={sourceTypeDEs}
+                            sourceTypeDEs={[]}
                             rows={rows}
                         />
                     );

--- a/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotals.tsx
@@ -26,12 +26,20 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
     const { dataFormInfo, section } = props;
 
     const grid = React.useMemo(
-        () => GridWithTotalsViewModel.get(section, dataFormInfo.metadata.dataForm.dataElements),
-        [section, dataFormInfo.metadata.dataForm.dataElements]
+        () =>
+            GridWithTotalsViewModel.get(
+                section,
+                dataFormInfo.metadata.dataForm.dataElements,
+                dataFormInfo.metadata.dataForm.options.dataElements
+            ),
+        [section, dataFormInfo.metadata.dataForm.dataElements, dataFormInfo.metadata.dataForm.options.dataElements]
     );
     const classes = useStyles();
 
-    const fistSection = section.id !== "yzMn16Bp1wV";
+    const currentSectionIndex = dataFormInfo.metadata.dataForm.sections.findIndex(
+        allSections => allSections.id === section.id
+    );
+    const notFirstSection = currentSectionIndex !== 0;
 
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo}>
@@ -53,7 +61,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                         </DataTableColumnHeader>
                                     );
                                 })}
-                                {section.id === "yzMn16Bp1wV" && <DataTableColumnHeader></DataTableColumnHeader>}
+                                {!notFirstSection && <DataTableColumnHeader></DataTableColumnHeader>}
                             </DataTableRow>
                         )}
                         <DataTableRow>
@@ -65,7 +73,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                 <DataTableColumnHeader></DataTableColumnHeader>
                             )}
 
-                            {fistSection ? (
+                            {notFirstSection ? (
                                 <DataTableColumnHeader className={classes.columnWidth} key={`column-Total`}>
                                     <span>Total</span>
                                 </DataTableColumnHeader>
@@ -82,7 +90,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                 ) : (
                                     <DataTableColumnHeader
                                         key={`column-${column.name}`}
-                                        className={column.name === "Source Type" ? classes.source : classes.columnWidth}
+                                        className={column.isSourceType ? classes.source : classes.columnWidth}
                                     >
                                         <span>{column.name}</span>
                                     </DataTableColumnHeader>
@@ -104,7 +112,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                     </p>
                                 </DataTableCell>
 
-                                {fistSection && row.total ? (
+                                {notFirstSection && row.total ? (
                                     <DataTableCell key={row.total.id + row.total.cocId}>
                                         <DataElementItem
                                             dataElement={row.total}
@@ -116,7 +124,7 @@ const GridWithTotals: React.FC<GridWithTotalsProps> = props => {
                                 ) : null}
 
                                 {row.items.map((item, idx) => {
-                                    if (item.column.name === "Source Type") {
+                                    if (item.column.isSourceType) {
                                         return item.dataElement ? (
                                             <DataTableCell key={item.dataElement.id + item.dataElement.cocId}>
                                                 <DataElementItem

--- a/src/webapp/reports/autogenerated-forms/GridWithTotalsViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithTotalsViewModel.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import { Section, SectionWithTotals, Texts } from "../../../domain/common/entities/DataForm";
 import { DataElement } from "../../../domain/common/entities/DataElement";
+import { Maybe } from "../../../utils/ts-utils";
 
 export interface Grid {
     id: string;
@@ -23,6 +24,7 @@ interface Column {
     name: string;
     deName?: string;
     cocName?: string;
+    isSourceType: boolean;
 }
 
 export interface Row {
@@ -47,7 +49,11 @@ type ParentColumn = {
 const separator = " - ";
 
 export class GridWithTotalsViewModel {
-    static get(section: SectionWithTotals, sectionDataElements: DataElement[]): Grid {
+    static get(
+        section: SectionWithTotals,
+        sectionDataElements: DataElement[],
+        dataElementsConfig: Record<string, { widget: Maybe<"dropdown" | "radio" | "sourceType"> }>
+    ): Grid {
         const dataElements = getDataElementsWithIndexProccessing(section);
 
         const subsections = _(dataElements)
@@ -63,15 +69,18 @@ export class GridWithTotalsViewModel {
             .uniqBy(de => de.name)
             .map(de => {
                 const categoryOptionCombos = de.categoryCombos.categoryOptionCombos;
+                const config = dataElementsConfig[de.id];
                 if (categoryOptionCombos.length !== 1 && categoryOptionCombos[0]?.name !== "default") {
                     return {
                         name: de.name,
                         deName: _(de.name).split(separator).head(),
                         cocName: _(de.name).split(separator).last(),
+                        isSourceType: false,
                     };
                 } else {
                     return {
                         name: de.name,
+                        isSourceType: config?.widget === "sourceType",
                     };
                 }
             })


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

Right now the name is being used to validate if the column is "Source Type". This PR change that logic, now it'll will get that information from the dataStore: `dataElements->widget`

### :art: Screenshots

![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/1499dc36-9fb5-43fe-9c69-84594dbb6878)

### :fire: Notes to the tester

Build custom form

```bash
yarn build-autogenerated-forms
```
