### PR TITLE
build translations from categoryOptions instead categoryCombinations

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -62,6 +62,10 @@ const dataElementFields = {
             categoryOptions: {
                 id: true,
                 code: true,
+                name: true,
+                displayName: true,
+                displayFormName: true,
+                displayShortName: true,
             },
         },
     },
@@ -108,7 +112,20 @@ function getCocOrdered(categoryCombo: D2DataElement["categoryCombo"], config: Dh
         const match = categoryCombo.categoryOptionCombos.find(coc => {
             return coc.name === cocOrdered;
         });
-        const categoryOption = allCategoryOptions.find(c => c.name === match?.name);
+
+        const optionsNames = match?.categoryOptions.map(co => co.displayName);
+        const optionsShortNames = match?.categoryOptions.map(co => co.displayShortName);
+        const optionsFormNames = match?.categoryOptions.map(co => co.displayFormName);
+
+        const categoryOption =
+            categoryCombo.categories.length === 1
+                ? allCategoryOptions.find(c => c.name === match?.name)
+                : {
+                      displayName: optionsNames?.join(", "),
+                      shortName: optionsShortNames?.join(", "),
+                      formName: optionsFormNames?.join(", "),
+                  };
+
         return match
             ? {
                   ...match,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694jb0zu

### :memo: Implementation

Use category options metadata instead dhis2 autogenerated combinations.

### :art: Screenshots

**Spanish** 
![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/d4c62539-d88f-4966-8b9e-756fb2313e6d)

**French**
![image](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/f0156efa-6eb1-4de1-883c-0f7a64e8d326)

### :fire: Notes to the tester

```bash
yarn build-autogenerated-forms
```

#8694jb0zu