### PR TITLE
[Feature] Add basic entities tests 

### DIFF
--- a/src/domain/common/entities/DataValue.ts
+++ b/src/domain/common/entities/DataValue.ts
@@ -11,7 +11,7 @@ import {
     DataElementText,
 } from "./DataElement";
 
-interface DataValueBase {
+export interface DataValueBase {
     orgUnitId: Id;
     period: Period;
     categoryOptionComboId: Id;

--- a/src/domain/common/entities/ValidationRule.ts
+++ b/src/domain/common/entities/ValidationRule.ts
@@ -1,7 +1,7 @@
 import { Maybe } from "../../../utils/ts-utils";
 import { Id } from "./Base";
 
-const allowedRules = [
+export const allowedRules = [
     {
         name: "equal_to",
         operator: "=",

--- a/src/domain/common/entities/__tests__/Config.spec.ts
+++ b/src/domain/common/entities/__tests__/Config.spec.ts
@@ -1,0 +1,19 @@
+import { getPath } from "../OrgUnit";
+import { getMainUserPaths } from "../Config";
+import { config } from "./configFixtures";
+import { orgUnits } from "./orgUnitFixtures";
+
+describe("Config", () => {
+    describe("getMainUserPaths", () => {
+        it("should return the compacted result of getPath", () => {
+            const result = getMainUserPaths(config);
+            expect(result).toEqual([getPath(orgUnits)]);
+        });
+
+        it("should handle empty paths correctly", () => {
+            const userWithoutOrgUnits = { ...config.currentUser, orgUnits: [] };
+            const result = getMainUserPaths({ ...config, currentUser: userWithoutOrgUnits });
+            expect(result).toEqual([]);
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/DataElement.spec.ts
+++ b/src/domain/common/entities/__tests__/DataElement.spec.ts
@@ -1,0 +1,37 @@
+import { getDataElementWithCode, DataElement, DataElementBoolean, DataElementText } from "../DataElement";
+import { dataElementBase } from "./dataFixtures";
+
+describe("DataElement module", () => {
+    const dataElementBoolean: DataElementBoolean = {
+        ...dataElementBase,
+        id: "1",
+        code: "DE_BOOLEAN",
+        name: "Boolean Data Element",
+        type: "BOOLEAN",
+        isTrueOnly: false,
+    };
+
+    const dataElementText: DataElementText = {
+        ...dataElementBase,
+        id: "2",
+        code: "DE_TEXT",
+        name: "Text Data Element",
+        type: "TEXT",
+    };
+
+    const dataElements: DataElement[] = [dataElementBoolean, dataElementText];
+
+    describe("getDataElementWithCode", () => {
+        it("should return the correct DataElement when a matching code is found", () => {
+            const codeToFind = "DE_BOOLEAN";
+            const result = getDataElementWithCode(dataElements, codeToFind);
+            expect(result).toEqual(dataElementBoolean);
+        });
+
+        it("should return undefined when no matching code is found", () => {
+            const codeToFind = "NON_EXISTENT_CODE";
+            const result = getDataElementWithCode(dataElements, codeToFind);
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/DataElement.spec.ts
+++ b/src/domain/common/entities/__tests__/DataElement.spec.ts
@@ -1,7 +1,7 @@
 import { getDataElementWithCode, DataElement, DataElementBoolean, DataElementText } from "../DataElement";
 import { dataElementBase } from "./dataFixtures";
 
-describe("DataElement module", () => {
+describe("DataElement", () => {
     const dataElementBoolean: DataElementBoolean = {
         ...dataElementBase,
         id: "1",

--- a/src/domain/common/entities/__tests__/DataElement.spec.ts
+++ b/src/domain/common/entities/__tests__/DataElement.spec.ts
@@ -1,5 +1,5 @@
 import { getDataElementWithCode, DataElement, DataElementBoolean, DataElementText } from "../DataElement";
-import { dataElementBase } from "./dataFixtures";
+import { dataElementText as dataElementBase } from "./dataFixtures";
 
 describe("DataElement", () => {
     const dataElementBoolean: DataElementBoolean = {

--- a/src/domain/common/entities/__tests__/DataForm.spec.ts
+++ b/src/domain/common/entities/__tests__/DataForm.spec.ts
@@ -1,0 +1,87 @@
+import { DataFormM, DataForm, SectionWithPeriods, SectionSimple } from "../DataForm";
+import { Period } from "../DataValue";
+import { sectionBase, dataFormBase } from "./dataFixtures";
+
+describe("DataFormM", () => {
+    describe("getReferencedPeriods", () => {
+        it("should return basePeriod when there are no additional periods", () => {
+            const dataForm: DataForm = {
+                ...dataFormBase,
+                sections: [],
+            };
+
+            const basePeriod: Period = "202101";
+            const result = DataFormM.getReferencedPeriods(dataForm, basePeriod);
+
+            expect(result).toEqual([basePeriod]);
+        });
+
+        it("should return unique periods from sections and basePeriod", () => {
+            const sections: SectionWithPeriods[] = [
+                createSectionWithPeriods("1", ["202102", "202103"]),
+                createSectionWithPeriods("2", ["202104", "202105"]),
+            ];
+
+            const dataForm: DataForm = {
+                ...dataFormBase,
+                sections,
+            };
+
+            const basePeriod: Period = "202101";
+            const result = DataFormM.getReferencedPeriods(dataForm, basePeriod);
+
+            expect(result).toEqual(["202101", "202102", "202103", "202104", "202105"]);
+        });
+
+        it("should handle mixed section types", () => {
+            const sections = [createSectionWithPeriods("1", ["202102", "202103"]), createSectionSimple("2")];
+
+            const dataForm: DataForm = {
+                ...dataFormBase,
+                sections,
+            };
+
+            const basePeriod: Period = "202101";
+            const result = DataFormM.getReferencedPeriods(dataForm, basePeriod);
+
+            expect(result).toEqual(["202101", "202102", "202103"]);
+        });
+
+        it("should return sorted unique periods", () => {
+            const sections = [
+                createSectionWithPeriods("1", ["202103", "202102"]),
+                createSectionWithPeriods("2", ["202105", "202104"]),
+                createSectionWithPeriods("3", ["202101", "202106"]),
+            ];
+
+            const dataForm: DataForm = {
+                ...dataFormBase,
+                sections,
+            };
+
+            const basePeriod: Period = "202100";
+            const result = DataFormM.getReferencedPeriods(dataForm, basePeriod);
+
+            expect(result).toEqual(["202100", "202101", "202102", "202103", "202104", "202105", "202106"]);
+        });
+    });
+});
+
+function createSectionSimple(id: string): SectionSimple {
+    return {
+        id,
+        name: `Section ${id}`,
+        viewType: "grid-with-combos",
+        ...sectionBase,
+    };
+}
+
+function createSectionWithPeriods(id: string, periods: Period[]): SectionWithPeriods {
+    return {
+        id,
+        name: `Section ${id}`,
+        viewType: "grid-with-periods",
+        periods,
+        ...sectionBase,
+    };
+}

--- a/src/domain/common/entities/__tests__/DataValue.spec.ts
+++ b/src/domain/common/entities/__tests__/DataValue.spec.ts
@@ -1,0 +1,48 @@
+import { DataValueStore } from "../DataValue";
+import { dataElementText, dataValues, dataValueTextSingle, dataValueBase } from "./dataFixtures";
+
+describe("DataValueStore", () => {
+    describe("DataValueStore.from", () => {
+        it("should create a DataValueStore from an array of DataValues", () => {
+            const store = DataValueStore.from(dataValues);
+            expect(store).toBeInstanceOf(DataValueStore);
+            expect(store.store).toEqual({
+                "1.202101.coc1.org1": dataValueTextSingle,
+            });
+        });
+    });
+
+    describe("DataValueStore.set", () => {
+        it("should set a DataValue in the store", () => {
+            const store = new DataValueStore({});
+            const updatedStore = store.set(dataValueTextSingle);
+            expect(updatedStore.store).toEqual({
+                "1.202101.coc1.org1": dataValueTextSingle,
+            });
+        });
+    });
+
+    describe("DataValueStore.get", () => {
+        it("should get a DataValue from the store", () => {
+            const store = DataValueStore.from(dataValues);
+            const dataValue = store.get(dataElementText, dataValueBase);
+            expect(dataValue).toEqual(dataValueTextSingle);
+        });
+    });
+
+    describe("DataValueStore.getOrEmpty", () => {
+        it("should get a DataValue from the store", () => {
+            const store = DataValueStore.from(dataValues);
+            const dataValue = store.getOrEmpty(dataElementText, dataValueBase);
+            expect(dataValue).toEqual(dataValueTextSingle);
+        });
+
+        it("should return an empty DataValue if not in the store", () => {
+            const store = new DataValueStore({});
+            const dataValue = store.getOrEmpty(dataElementText, dataValueBase);
+
+            const emptyDataValue = { ...dataValueTextSingle, value: "" };
+            expect(dataValue).toEqual(emptyDataValue);
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/Indicator.spec.ts
+++ b/src/domain/common/entities/__tests__/Indicator.spec.ts
@@ -1,0 +1,37 @@
+import { Indicator, checkIndicatorDirection, getIndicatorRelatedToDataElement, IndicatorDirection } from "../Indicator";
+import { indicatorAfter, indicatorBefore, indicators } from "./indicatorFixtures";
+
+describe("Indicator", () => {
+    describe("checkIndicatorDirection", () => {
+        it("should return true when the indicator's direction matches the provided direction", () => {
+            const direction: IndicatorDirection = "after";
+
+            // indicatorAfter indicator contain { direction: "after" }
+            const result = checkIndicatorDirection(indicatorAfter, direction);
+            expect(result).toBe(true);
+        });
+
+        it("should return false when the indicator's direction does not match the provided direction", () => {
+            const direction: IndicatorDirection = "after";
+
+            // indicatorBefore indicator contain { direction: "before" }
+            const result = checkIndicatorDirection(indicatorBefore, direction);
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("getIndicatorRelatedToDataElement", () => {
+        it("should return the indicator related to the specified data element code", () => {
+            const codeToFind = "DE_1";
+            const result = getIndicatorRelatedToDataElement(indicators, codeToFind);
+            // indicatorAfter indicator contain dataElement: { code: "DE_1", direction: "after" }
+            expect(result).toEqual(indicatorAfter);
+        });
+
+        it("should return undefined when no indicator is related to the specified data element code", () => {
+            const codeToFind = "NON_EXISTENT_CODE";
+            const result = getIndicatorRelatedToDataElement(indicators, codeToFind);
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/OrgUnit.spec.ts
+++ b/src/domain/common/entities/__tests__/OrgUnit.spec.ts
@@ -1,0 +1,61 @@
+import {
+    OrgUnitPath,
+    getRoots,
+    getRootIds,
+    getPath,
+    getOrgUnitIdsFromPaths,
+    getOrgUnitParentPath,
+    getOrgUnitsFromId,
+} from "../OrgUnit";
+import { childrenOrgUnits, orgUnits, rootOrgUnits } from "./orgUnitFixtures";
+
+describe("OrgUnit", () => {
+    describe("getRoots", () => {
+        it("should return the root org units", () => {
+            const result = getRoots(orgUnits);
+            expect(result).toEqual(rootOrgUnits);
+        });
+    });
+
+    describe("getRootIds", () => {
+        it("should return the ids of root org units", () => {
+            const expectedRootIds = ["1", "4"];
+            const result = getRootIds(orgUnits);
+            expect(result).toEqual(expectedRootIds);
+        });
+    });
+
+    describe("getPath", () => {
+        it("should return the path of the first root org unit", () => {
+            const expectedPath = "/1";
+            const result = getPath(orgUnits);
+            expect(result).toEqual(expectedPath);
+        });
+    });
+
+    describe("getOrgUnitIdsFromPaths", () => {
+        it("should return the ids extracted from org unit paths", () => {
+            const orgUnitPathsSelected: OrgUnitPath[] = ["/1/2", "/1/3"];
+            const expectedOrgUnitIds = ["2", "3"];
+            const result = getOrgUnitIdsFromPaths(orgUnitPathsSelected);
+            expect(result).toEqual(expectedOrgUnitIds);
+        });
+    });
+
+    describe("getOrgUnitParentPath", () => {
+        it("should return the parent path of the given org unit path", () => {
+            const path = "/1/2";
+            const expectedParentPath = "/1";
+            const result = getOrgUnitParentPath(path);
+            expect(result).toEqual(expectedParentPath);
+        });
+    });
+
+    describe("getOrgUnitsFromId", () => {
+        it("should return org units with the given ids", () => {
+            const orgUnitIds = ["2", "3"];
+            const result = getOrgUnitsFromId(orgUnitIds, orgUnits);
+            expect(result).toEqual(childrenOrgUnits);
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/ToggleMultiple.spec.ts
+++ b/src/domain/common/entities/__tests__/ToggleMultiple.spec.ts
@@ -1,0 +1,59 @@
+import { buildToggleMultiple, DataElementToggle, ToggleMultiple } from "../ToggleMultiple";
+import { DataElement } from "../DataElement";
+import { dataElementText as dataElementBase } from "./dataFixtures";
+
+// Mock console.warn to catch warnings in test output
+global.console = { ...global.console, warn: jest.fn() };
+
+describe("buildToggleMultiple", () => {
+    const dataElement1: DataElement = {
+        ...dataElementBase,
+        id: "1",
+        code: "DE_1",
+        name: "Text Data Element 1",
+        type: "TEXT",
+    };
+
+    const dataElement2: DataElement = {
+        ...dataElementBase,
+        id: "2",
+        code: "DE_2",
+        name: "Text Data Element 2",
+        type: "TEXT",
+    };
+
+    const dataElements: Record<string, DataElement> = {
+        dataElement1,
+        dataElement2,
+    };
+
+    const toggleMultiple: ToggleMultiple[] = [
+        { dataElement: "DE_1", condition: "condition1" },
+        { dataElement: "DE_2", condition: "condition2" },
+        { dataElement: "DE_3", condition: "condition3" }, // DE_3 does not exist in dataElements
+    ];
+
+    it("should return the correct DataElementToggle array", () => {
+        const expected: DataElementToggle[] = [
+            { dataElement: dataElement1, condition: "condition1" },
+            { dataElement: dataElement2, condition: "condition2" },
+        ];
+
+        const result = buildToggleMultiple(toggleMultiple, dataElements);
+        expect(result).toEqual(expected);
+    });
+
+    it("should log a warning for missing data elements", () => {
+        buildToggleMultiple(toggleMultiple, dataElements);
+        expect(console.warn).toHaveBeenCalledWith("Cannot found DE_3 in toggleMultiple config.");
+    });
+
+    it("should return an empty array if no matching data elements are found", () => {
+        const toggleMultipleNone: ToggleMultiple[] = [
+            { dataElement: "DE_4", condition: "condition4" },
+            { dataElement: "DE_5", condition: "condition5" },
+        ];
+        const result = buildToggleMultiple(toggleMultipleNone, dataElements);
+        expect(result).toEqual([]);
+    });
+});

--- a/src/domain/common/entities/__tests__/ValidationRule.spec.ts
+++ b/src/domain/common/entities/__tests__/ValidationRule.spec.ts
@@ -1,0 +1,46 @@
+import { ValidationRule, allowedRules } from "../ValidationRule";
+
+describe("ValidationRule", () => {
+    describe("constructor", () => {
+        it("should initialize correctly with given parameters", () => {
+            const id = "rule1";
+            const description = "This is a test rule";
+            const operator = "equal_to";
+
+            const rule = new ValidationRule(id, description, operator);
+
+            expect(rule.id).toBe(id);
+            expect(rule.message).toBe(description);
+            expect(rule.operator).toBe(operator);
+        });
+    });
+
+    describe("oppositeOperatorName", () => {
+        it("should return the opposite operator name when the operator is valid", () => {
+            const id = "rule1";
+            const description = "This is a test rule";
+            const operator = "equal_to";
+
+            const rule = new ValidationRule(id, description, operator);
+
+            expect(rule.oppositeOperatorName).toBe("!=");
+        });
+
+        it("should return undefined when the operator is invalid", () => {
+            const id = "rule1";
+            const description = "This is a test rule";
+            const operator = "invalid_operator";
+
+            const rule = new ValidationRule(id, description, operator);
+
+            expect(rule.oppositeOperatorName).toBeUndefined();
+        });
+
+        it("should return the correct opposite operator for all allowed rules", () => {
+            allowedRules.forEach(rule => {
+                const validationRule = new ValidationRule("rule1", "Test rule", rule.name);
+                expect(validationRule.oppositeOperatorName).toBe(rule.opposite);
+            });
+        });
+    });
+});

--- a/src/domain/common/entities/__tests__/configFixtures.ts
+++ b/src/domain/common/entities/__tests__/configFixtures.ts
@@ -1,0 +1,28 @@
+import { Config } from "../Config";
+import { orgUnits } from "./orgUnitFixtures";
+
+export const config: Config = {
+    dataSets: undefined,
+    sections: undefined,
+    currentUser: {
+        id: "1",
+        name: "Test User",
+        username: "User",
+        orgUnits: orgUnits,
+        userRoles: [],
+        userGroups: [],
+    },
+    sqlViews: undefined,
+    pairedDataElementsByDataSet: undefined,
+    orgUnits: undefined,
+    sectionsByDataSet: undefined,
+    years: undefined,
+    approvalWorkflow: undefined,
+    categoryOptionCombos: {
+        default: { id: "defaultCoc" },
+    },
+    translations: {
+        yes: "Yes",
+        no: "No",
+    },
+};

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -1,7 +1,7 @@
 import { DataForm, SectionBase, defaultTexts } from "../DataForm";
 import { DataElement } from "../DataElement";
 
-const dataElementBase: DataElement = {
+export const dataElementBase: DataElement = {
     id: "1",
     code: "1",
     name: `Element 1`,

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -4,7 +4,7 @@ import { DataValue, DataValueBase, DataValueTextSingle } from "../DataValue";
 
 export const dataElementText: DataElementText = {
     id: "1",
-    code: "1",
+    code: "DE1",
     name: "Element 1",
     type: "TEXT",
     categoryCombos: {

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -1,10 +1,11 @@
 import { DataForm, SectionBase, defaultTexts } from "../DataForm";
-import { DataElement } from "../DataElement";
+import { DataElementText } from "../DataElement";
+import { DataValue, DataValueBase, DataValueTextSingle } from "../DataValue";
 
-export const dataElementBase: DataElement = {
+export const dataElementText: DataElementText = {
     id: "1",
     code: "1",
-    name: `Element 1`,
+    name: "Element 1",
     type: "TEXT",
     categoryCombos: {
         id: "1",
@@ -37,7 +38,7 @@ export const sectionBase: Omit<SectionBase, "id" | "name" | "viewType"> = {
     showRowTotals: false,
     toggleMultiple: [],
     indicators: [],
-    dataElements: [dataElementBase],
+    dataElements: [dataElementText],
 };
 
 export const dataFormBase: Omit<DataForm, "sections"> = {
@@ -49,3 +50,19 @@ export const dataFormBase: Omit<DataForm, "sections"> = {
     options: { dataElements: {} },
     indicators: [],
 };
+
+export const dataValueBase: DataValueBase = {
+    orgUnitId: "org1",
+    period: "202101",
+    categoryOptionComboId: "coc1",
+};
+
+export const dataValueTextSingle: DataValueTextSingle = {
+    ...dataValueBase,
+    type: "TEXT",
+    isMultiple: false,
+    dataElement: dataElementText,
+    value: "Sample text",
+};
+
+export const dataValues: DataValue[] = [dataValueTextSingle];

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -1,0 +1,51 @@
+import { DataForm, SectionBase, defaultTexts } from "../DataForm";
+import { DataElement } from "../DataElement";
+
+const dataElementBase: DataElement = {
+    id: "1",
+    code: "1",
+    name: `Element 1`,
+    type: "TEXT",
+    categoryCombos: {
+        id: "1",
+        name: "Combo",
+        categoryOptionCombos: [
+            {
+                id: "1",
+                name: "Option Combo",
+                shortName: "OC",
+                formName: undefined,
+            },
+        ],
+    },
+    categoryOptionCombos: [],
+    rules: [],
+    htmlText: undefined,
+    related: undefined,
+};
+
+export const sectionBase: Omit<SectionBase, "id" | "name" | "viewType"> = {
+    toggle: { type: "none" },
+    texts: defaultTexts,
+    tabs: { active: true },
+    sortRowsBy: "name",
+    titleVariant: "h1",
+    styles: { title: {}, columns: {}, rows: {}, totals: {} },
+    columnsDescriptions: undefined,
+    groupDescriptions: undefined,
+    disableComments: false,
+    showRowTotals: false,
+    toggleMultiple: [],
+    indicators: [],
+    dataElements: [dataElementBase],
+};
+
+export const dataFormBase: Omit<DataForm, "sections"> = {
+    id: "1",
+    expiryDays: 0,
+    dataInputPeriods: [],
+    dataElements: [],
+    texts: defaultTexts,
+    options: { dataElements: {} },
+    indicators: [],
+};

--- a/src/domain/common/entities/__tests__/indicatorFixtures.ts
+++ b/src/domain/common/entities/__tests__/indicatorFixtures.ts
@@ -1,0 +1,19 @@
+import { Indicator } from "../Indicator";
+
+export const indicatorAfter: Indicator = {
+    id: "1",
+    code: "IND_1",
+    description: "Indicator 1",
+    formula: "formula_1",
+    dataElement: { code: "DE_1", direction: "after" },
+};
+
+export const indicatorBefore: Indicator = {
+    id: "2",
+    code: "IND_2",
+    description: "Indicator 2",
+    formula: "formula_2",
+    dataElement: { code: "DE_2", direction: "before" },
+};
+
+export const indicators: Indicator[] = [indicatorAfter, indicatorBefore];

--- a/src/domain/common/entities/__tests__/orgUnitFixtures.ts
+++ b/src/domain/common/entities/__tests__/orgUnitFixtures.ts
@@ -1,0 +1,13 @@
+import { OrgUnit } from "../OrgUnit";
+
+export const rootOrgUnits: OrgUnit[] = [
+    { id: "1", path: "/1", name: "OrgUnit1", level: 1 },
+    { id: "4", path: "/4", name: "OrgUnit4", level: 1 },
+];
+
+export const childrenOrgUnits: OrgUnit[] = [
+    { id: "2", path: "/1/2", name: "OrgUnit2", level: 2 },
+    { id: "3", path: "/1/3", name: "OrgUnit3", level: 2 },
+];
+
+export const orgUnits: OrgUnit[] = [...rootOrgUnits, ...childrenOrgUnits];


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694jf6w2
- 8694jf6w2

### :memo: Implementation

Added some basic tests for entities :
- `Config`
- `DataElement`
- `DataForm`
- `DataValue`
- `Indicator`
- `OrgUnit`
- `ToggleMultiple`
- `ValidationRule`

### :fire: Notes to the tester

Docker used: `docker.eyeseetea.com/eyeseetea/dhis2-data:2.34-play`

Run `yarn test`