### PR TITLE
chore: test SaveDataFormValue use case

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "prettier": "2.4.1",
         "react-test-renderer": "17.0.2",
         "ts-jest": "27.0.7",
+        "ts-mockito": "^2.6.1",
         "ts-node": "10.4.0",
         "typescript": "4.5.2",
         "wait-on": "6.0.0"

--- a/src/domain/common/usecases/__tests__/SaveDataFormValue.spec.ts
+++ b/src/domain/common/usecases/__tests__/SaveDataFormValue.spec.ts
@@ -1,0 +1,87 @@
+import { SaveDataFormValueUseCase } from "../SaveDataFormValue";
+import { DataValue, DataValueStore } from "../../entities/DataValue";
+import { DataValueRepository } from "../../repositories/DataValueRepository";
+import { instance, mock, when, verify, anything, deepEqual } from "ts-mockito";
+import { Dhis2DataValueRepository } from "../../../../data/common/Dhis2DataValueRepository";
+import { dataValueText, dataValueFile } from "./data/dataValue";
+
+let mockDataValueRepository: DataValueRepository;
+let mockDataValueStore: DataValueStore;
+
+describe("SaveDataFormValueUseCase", () => {
+    beforeEach(() => {
+        mockDataValueRepository = mock<DataValueRepository>(Dhis2DataValueRepository);
+        mockDataValueStore = mock<DataValueStore>(DataValueStore);
+    });
+
+    it("returns the store if the existing data value is equal to the new data value and type is not FILE", async () => {
+        const useCase = givenSaveDataFormValueUseCase();
+        const dataValue = dataValueText;
+        givenExistingDataValue(dataValue);
+
+        const stubDataValueStore = instance(mockDataValueStore);
+
+        const result = await useCase.execute(stubDataValueStore, dataValue);
+
+        verify(mockDataValueStore.get(dataValue.dataElement, dataValue)).once();
+        verify(mockDataValueStore.set(anything())).never();
+        verify(mockDataValueRepository.save(anything())).never();
+        expect(result).toBe(stubDataValueStore);
+    });
+
+    it("updates the store with the new data value and saves it", async () => {
+        const useCase = givenSaveDataFormValueUseCase();
+        const dataValue = dataValueText;
+        const saveDataValue = { ...dataValueText, value: "20" };
+        givenExistingDataValue(dataValue);
+        givenSavedDataValue(saveDataValue);
+
+        const dataValueStore = DataValueStore.from([dataValue]);
+        const saveDataValueStore = DataValueStore.from([saveDataValue]);
+
+        const result = await useCase.execute(dataValueStore, saveDataValue);
+
+        verify(mockDataValueRepository.save(deepEqual(saveDataValue))).once();
+        expect(result).toStrictEqual(saveDataValueStore);
+    });
+
+    it("updates the store with the new FILE data value and saves it", async () => {
+        const useCase = givenSaveDataFormValueUseCase();
+        const dataValue = dataValueFile;
+        const saveDataValue = {
+            ...dataValueFile,
+            file: {
+                id: "1",
+                name: "Test file",
+                size: 1024,
+                url: "/updated/path/to/file",
+            },
+        };
+        givenExistingDataValue(dataValue);
+        givenSavedDataValue(saveDataValue);
+
+        const dataValueStore = DataValueStore.from([dataValue]);
+        const saveDataValueStore = DataValueStore.from([saveDataValue]);
+
+        const result = await useCase.execute(dataValueStore, saveDataValue);
+
+        verify(mockDataValueRepository.save(deepEqual(saveDataValue))).once();
+        expect(result).toStrictEqual(saveDataValueStore);
+    });
+});
+
+function givenSaveDataFormValueUseCase() {
+    const stubDataValueRepository = instance(mockDataValueRepository);
+    return new SaveDataFormValueUseCase(stubDataValueRepository);
+}
+
+function givenExistingDataValue(dataValue: DataValue) {
+    when(mockDataValueStore.get(dataValue.dataElement, dataValue)).thenReturn(dataValue);
+}
+
+function givenSavedDataValue(savedDataValue: DataValue) {
+    const stubDataValueStore = instance(mockDataValueStore);
+
+    when(mockDataValueRepository.save(savedDataValue)).thenResolve(savedDataValue);
+    when(mockDataValueStore.set(savedDataValue)).thenReturn(stubDataValueStore);
+}

--- a/src/domain/common/usecases/__tests__/data/dataValue.ts
+++ b/src/domain/common/usecases/__tests__/data/dataValue.ts
@@ -1,0 +1,80 @@
+import { DataElement } from "../../../entities/DataElement";
+import { DataValueFile, DataValueTextSingle } from "../../../entities/DataValue";
+
+const dataElement: Omit<DataElement, "type"> = {
+    id: "1",
+    code: "DE1",
+    name: "Element 1",
+    categoryCombos: {
+        id: "1",
+        name: "Combo",
+        categoryOptionCombos: [
+            {
+                id: "1",
+                name: "Option Combo",
+                shortName: "OC",
+                formName: undefined,
+            },
+        ],
+    },
+    categoryOptionCombos: [],
+    rules: [],
+    htmlText: undefined,
+    related: undefined,
+};
+
+export const dataValueText: DataValueTextSingle = {
+    dataElement: { ...dataElement, type: "TEXT" },
+    period: "202101",
+    orgUnitId: "ou1",
+    categoryOptionComboId: "coc1",
+    isMultiple: false,
+    type: "TEXT",
+    value: "10",
+};
+
+export const dataValueFile: DataValueFile = {
+    dataElement: { ...dataElement, type: "FILE" },
+    period: "202101",
+    orgUnitId: "ou1",
+    categoryOptionComboId: "coc1",
+    isMultiple: false,
+    type: "FILE",
+    file: {
+        id: "1",
+        name: "Test file",
+        size: 1024,
+        url: "/path/to/file",
+    },
+};
+
+// function givenDataValueText(overrides: Partial<DataValueTextSingle> = {}): DataValueTextSingle {
+//     return {
+//         dataElement: { ...dataElement, type: "TEXT" },
+//         period: "202101",
+//         orgUnitId: "ou1",
+//         categoryOptionComboId: "coc1",
+//         isMultiple: false,
+//         type: "TEXT",
+//         value: "10",
+//         ...overrides,
+//     };
+// }
+
+// function givenDataValueFile(overrides: Partial<DataValueFile> = {}): DataValueFile {
+//     return {
+//         dataElement: { ...dataElement, type: "FILE" },
+//         period: "202101",
+//         orgUnitId: "ou1",
+//         categoryOptionComboId: "coc1",
+//         isMultiple: false,
+//         type: "FILE",
+//         file: {
+//             id: "1",
+//             name: "Test file",
+//             size: 1024,
+//             url: "/path/to/file",
+//         },
+//         ...overrides,
+//     };
+// }

--- a/src/domain/common/usecases/__tests__/data/dataValue.ts
+++ b/src/domain/common/usecases/__tests__/data/dataValue.ts
@@ -47,34 +47,3 @@ export const dataValueFile: DataValueFile = {
         url: "/path/to/file",
     },
 };
-
-// function givenDataValueText(overrides: Partial<DataValueTextSingle> = {}): DataValueTextSingle {
-//     return {
-//         dataElement: { ...dataElement, type: "TEXT" },
-//         period: "202101",
-//         orgUnitId: "ou1",
-//         categoryOptionComboId: "coc1",
-//         isMultiple: false,
-//         type: "TEXT",
-//         value: "10",
-//         ...overrides,
-//     };
-// }
-
-// function givenDataValueFile(overrides: Partial<DataValueFile> = {}): DataValueFile {
-//     return {
-//         dataElement: { ...dataElement, type: "FILE" },
-//         period: "202101",
-//         orgUnitId: "ou1",
-//         categoryOptionComboId: "coc1",
-//         isMultiple: false,
-//         type: "FILE",
-//         file: {
-//             id: "1",
-//             name: "Test file",
-//             size: 1024,
-//             url: "/path/to/file",
-//         },
-//         ...overrides,
-//     };
-// }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18391,6 +18391,13 @@ ts-jest@27.0.7:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
+
 ts-node@10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694jf6w2
- 8694jf6w2

### :memo: Implementation
Test SaveDataFormValue use cases :
- returns the store if the existing data value is equal to the new data value and type is not FILE
- updates the store with the new data value and saves it
- updates the store with the new FILE data value and saves it

### :fire: Notes to the tester
Docker used: `docker.eyeseetea.com/eyeseetea/dhis2-data:2.34-play`
Run `yarn test SaveDataFormValue.spec.ts` (to test only this file)