### PR TITLE
chore: test GetDataFormUseCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "prettier": "2.4.1",
         "react-test-renderer": "17.0.2",
         "ts-jest": "27.0.7",
+        "ts-mockito": "^2.6.1",
         "ts-node": "10.4.0",
         "typescript": "4.5.2",
         "wait-on": "6.0.0"

--- a/src/domain/common/usecases/__tests__/GetDataFormUseCase.spec.ts
+++ b/src/domain/common/usecases/__tests__/GetDataFormUseCase.spec.ts
@@ -1,11 +1,11 @@
 import { Dhis2DataFormRepository } from "../../../../data/common/Dhis2DataFormRepository";
 import { GetDataFormUseCase } from "../GetDataFormUseCase";
 import { DataFormRepository } from "../../repositories/DataFormRepository";
-import { Id } from "@eyeseetea/d2-api";
 import { Period } from "../../entities/DataValue";
 import { mock, instance, when, verify, deepEqual } from "ts-mockito";
 import { DataForm } from "../../entities/DataForm";
 import { dataForm } from "./data/dataForm";
+import { Id } from "../../entities/Base";
 
 describe("GetDataFormUseCase", () => {
     let mockDataFormRepository: DataFormRepository;

--- a/src/domain/common/usecases/__tests__/GetDataFormUseCase.spec.ts
+++ b/src/domain/common/usecases/__tests__/GetDataFormUseCase.spec.ts
@@ -1,0 +1,47 @@
+import { Dhis2DataFormRepository } from "../../../../data/common/Dhis2DataFormRepository";
+import { GetDataFormUseCase } from "../GetDataFormUseCase";
+import { DataFormRepository } from "../../repositories/DataFormRepository";
+import { Id } from "@eyeseetea/d2-api";
+import { Period } from "../../entities/DataValue";
+import { mock, instance, when, verify, deepEqual } from "ts-mockito";
+import { DataForm } from "../../entities/DataForm";
+import { dataForm } from "./data/dataForm";
+
+describe("GetDataFormUseCase", () => {
+    let mockDataFormRepository: DataFormRepository;
+    const dataSetId: Id = "dataSetId";
+    const period: Period = "202101";
+    const orgUnitId: Id = "orgUnitId";
+    const dataFormRepositoryGetOptions = { id: dataSetId, period, orgUnitId };
+    const options = { dataSetId, period, orgUnitId };
+
+    beforeEach(() => {
+        mockDataFormRepository = mock<DataFormRepository>(Dhis2DataFormRepository);
+    });
+
+    it("calls the repository with correct parameters and returns the data form", async () => {
+        const expectedDataForm: DataForm = {
+            id: dataSetId,
+            ...dataForm,
+        };
+
+        when(mockDataFormRepository.get(deepEqual(dataFormRepositoryGetOptions))).thenResolve(expectedDataForm);
+
+        const useCase = new GetDataFormUseCase(instance(mockDataFormRepository));
+        const result = await useCase.execute(options);
+
+        expect(result).toEqual(expectedDataForm);
+        verify(mockDataFormRepository.get(deepEqual(dataFormRepositoryGetOptions))).once();
+    });
+
+    it("handles errors thrown by the repository", async () => {
+        const expectedError = new Error("Repository error");
+
+        when(mockDataFormRepository.get(deepEqual(dataFormRepositoryGetOptions))).thenReject(expectedError);
+
+        const useCase = new GetDataFormUseCase(instance(mockDataFormRepository));
+
+        await expect(useCase.execute(options)).rejects.toThrow(expectedError);
+        verify(mockDataFormRepository.get(deepEqual(dataFormRepositoryGetOptions))).once();
+    });
+});

--- a/src/domain/common/usecases/__tests__/data/dataForm.ts
+++ b/src/domain/common/usecases/__tests__/data/dataForm.ts
@@ -1,0 +1,21 @@
+import { DataForm } from "../../../entities/DataForm";
+
+export const dataForm: Omit<DataForm, "id"> = {
+    expiryDays: 30,
+    dataInputPeriods: [],
+    dataElements: [],
+    sections: [],
+    texts: {
+        header: undefined,
+        footer: undefined,
+        rowTotals: undefined,
+        totals: undefined,
+        name: undefined,
+    },
+    options: {
+        dataElements: {
+            de1: { widget: "dropdown" },
+        },
+    },
+    indicators: [],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -18391,6 +18391,13 @@ ts-jest@27.0.7:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
+
 ts-node@10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694jf6w2
- 8694jf6w2

### :memo: Implementation
Test GetDataFormUseCase :
- calls the repository with correct parameters and returns the data form
- handles errors thrown by the repository

### :fire: Notes to the tester
Docker used: `docker.eyeseetea.com/eyeseetea/dhis2-data:2.34-play`
Run `yarn test GetDataFormUseCase.spec.ts` (to test only this file)