### PR TITLE
chore: test GetOrgUnitsUseCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
         "prettier": "2.4.1",
         "react-test-renderer": "17.0.2",
         "ts-jest": "27.0.7",
+        "ts-mockito": "^2.6.1",
         "ts-node": "10.4.0",
         "typescript": "4.5.2",
         "wait-on": "6.0.0"

--- a/src/domain/common/usecases/__tests__/GetOrgUnitsUseCase.spec.ts
+++ b/src/domain/common/usecases/__tests__/GetOrgUnitsUseCase.spec.ts
@@ -1,0 +1,41 @@
+import { Dhis2OrgUnitsRepository } from "../../../../data/common/Dhis2OrgUnitsRepository";
+import { OrgUnit, OrgUnitPath } from "../../entities/OrgUnit";
+import { OrgUnitsRepository } from "../../repositories/OrgUnitsRepository";
+import { GetOrgUnitsUseCase } from "../../usecases/GetOrgUnitsUseCase";
+import { mock, instance, when, verify, deepEqual } from "ts-mockito";
+
+describe("GetOrgUnitsUseCase", () => {
+    let mockOrgUnitsRepository: OrgUnitsRepository;
+
+    beforeEach(() => {
+        mockOrgUnitsRepository = mock<OrgUnitsRepository>(Dhis2OrgUnitsRepository);
+    });
+
+    it("calls the repository with correct parameters and returns the org units", async () => {
+        const paths: OrgUnitPath[] = ["/root/unit1", "/root"];
+        const expectedOrgUnits: OrgUnit[] = [
+            { id: "1", name: "Unit 1", path: "/root/unit1", level: 1 },
+            { id: "2", name: "Unit 2", path: "/root", level: 2 },
+        ];
+
+        when(mockOrgUnitsRepository.getFromPaths(deepEqual(paths))).thenResolve(expectedOrgUnits);
+
+        const useCase = new GetOrgUnitsUseCase(instance(mockOrgUnitsRepository));
+        const result = await useCase.execute({ paths });
+
+        expect(result).toEqual(expectedOrgUnits);
+        verify(mockOrgUnitsRepository.getFromPaths(deepEqual(paths))).once();
+    });
+
+    it("handles errors thrown by the repository", async () => {
+        const paths: OrgUnitPath[] = ["/root/unit1", "/root/unit2"];
+        const expectedError = new Error("Repository error");
+
+        when(mockOrgUnitsRepository.getFromPaths(deepEqual(paths))).thenReject(expectedError);
+
+        const useCase = new GetOrgUnitsUseCase(instance(mockOrgUnitsRepository));
+
+        await expect(useCase.execute({ paths })).rejects.toThrow(expectedError);
+        verify(mockOrgUnitsRepository.getFromPaths(deepEqual(paths))).once();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -18391,6 +18391,13 @@ ts-jest@27.0.7:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-mockito@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.6.1.tgz#bc9ee2619033934e6fad1c4455aca5b5ace34e73"
+  integrity sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==
+  dependencies:
+    lodash "^4.17.5"
+
 ts-node@10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694jf6w2
- 8694jf6w2

### :memo: Implementation
Test GetOrgUnitsUseCase use cases :
- calls the repository with correct parameters and returns the org units
- handles errors thrown by the repository

### :fire: Notes to the tester
Docker used: `docker.eyeseetea.com/eyeseetea/dhis2-data:2.34-play`
Run `yarn test GetOrgUnitsUseCase.spec.ts` (to test only this file)