### PR TITLE
remove datastore cache

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -8,8 +8,8 @@ import { Dhis2DataStoreDataForm } from "./Dhis2DataStoreDataForm";
 export class Dhis2DataElement {
     constructor(private api: D2Api) {}
 
-    async get(ids: Id[]): Promise<Record<Id, DataElement>> {
-        const config = await Dhis2DataStoreDataForm.build(this.api);
+    async get(ids: Id[], dataSetCode: string): Promise<Record<Id, DataElement>> {
+        const config = await Dhis2DataStoreDataForm.build(this.api, dataSetCode);
         const idGroups = _(ids).uniq().chunk(100).value();
 
         const resList = await promiseMap(idGroups, idsGroup =>

--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -81,7 +81,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
             .map(dataElement => ({ id: dataElement.id, code: dataElement.code }))
             .value();
 
-        const dataElements = await new Dhis2DataElement(this.api).get(dataElementIds);
+        const dataElements = await new Dhis2DataElement(this.api).get(dataElementIds, dataSet.code);
 
         const dataElementsRulesConfig = this.buildRulesFromConfig(dataElements, configDataForm, allDataElements);
         return dataSet.sections.map((section): Section => {

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -314,10 +314,16 @@ export class Dhis2DataStoreDataForm {
     }
 
     static async build(api: D2Api, dataSetCode?: string): Promise<Dhis2DataStoreDataForm> {
-        if (cachedStore) return cachedStore;
-
         const dataStore = api.dataStore(Namespaces.D2_AUTOGEN_FORMS);
-        if (!dataSetCode) throw Error(`Unable to load configuration: dataSetCode not defined`);
+        if (!dataSetCode) {
+            console.warn(`Unable to load configuration: dataSetCode not defined`);
+            return new Dhis2DataStoreDataForm({
+                optionSets: [],
+                constants: [],
+                custom: defaultDataStoreConfig,
+                subNationals: [],
+            });
+        }
         const storeValue = await dataStore.get<object>(dataSetCode).getData();
         if (!storeValue)
             return new Dhis2DataStoreDataForm({
@@ -350,8 +356,7 @@ export class Dhis2DataStoreDataForm {
             },
         });
 
-        cachedStore = new Dhis2DataStoreDataForm(config);
-        return cachedStore;
+        return new Dhis2DataStoreDataForm(config);
     }
 
     private static async getOptionSets(api: D2Api, storeConfig: DataFormStoreConfig["custom"]): Promise<OptionSet[]> {
@@ -650,8 +655,6 @@ interface Constant {
     code: Code;
     displayDescription: string;
 }
-
-let cachedStore: Dhis2DataStoreDataForm | undefined;
 
 function sectionConfig<T extends Record<string, Codec<any>>>(properties: T) {
     return optional(record(string, Codec.interface(properties)));


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694pj8da

### :memo: Implementation

Datastore config. was being cached so every time a new `dataSet` was selected it was not loading its configuration.

### :art: Screenshots

[autogen_form_datastore_bug.webm](https://github.com/EyeSeeTea/d2-autogen-forms/assets/461124/833656d3-b30e-4c10-b783-5fbe2d3136aa)

### :fire: Notes to the tester

Build 
```bash
yarn build-autogenerated-forms
```

#8694pj8da