### PR TITLE
enable input period validation if expiry days is 0

### DIFF
--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -38,8 +38,6 @@ function isInputExpired(
     dataInputPeriods: dataInputPeriodsType,
     expiryDays: number
 ) {
-    if (!expiryDays) return false;
-
     const periodToCheck = period ?? dataFormPeriod;
 
     const dataInputPeriod = dataInputPeriods?.find(p => p.period.id === periodToCheck);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86984thmk

### :memo: Implementation

- Right now all the inputs are enabled if expiryDays is equal to ZERO. I'm deleting that condition and always evaluate input periods.

### :art: Screenshots

Expiry days set to ZERO

![image](https://github.com/user-attachments/assets/3eae96a0-9e8a-4b24-9778-df7bf03ffb94)

2023 is disabled now:

[autogenform_expiry_days.webm](https://github.com/user-attachments/assets/bd9e4a50-3ba2-4daf-875b-c53777dd833a)


### :fire: Notes to the tester

#86984thmk