### PR TITLE
[fix]: Use constants to get totals formula for each column

### DIFF
--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -459,13 +459,18 @@ export class Dhis2DataStoreDataForm {
             .flatMap(dataSet => _.values(dataSet.sections))
             .flatMap(section => {
                 if (!section.totals) return undefined;
+
+                const formulaCodes = _(section.totals.formulas)
+                    .map((_, key) => key)
+                    .compact()
+                    .value();
+
                 return this.isSectionTotals(section.totals)
-                    ? [section.totals.texts]
+                    ? [section.totals.texts?.code, ...formulaCodes]
                     : _(section.totals)
-                          .map(total => total.texts)
+                          .map(total => total.texts?.code)
                           .value();
             })
-            .map(totals => totals?.code)
             .compact()
             .value();
 
@@ -657,6 +662,11 @@ export class Dhis2DataStoreDataForm {
                     texts: {
                         name: this.getTextFromConstants(sectionTotalsText, constantsByCode) || "",
                     },
+                    formulas: _(totals.formulas)
+                        .mapKeys((_, key) =>
+                            constantsByCode[key] ? this.getTextFromConstants({ code: key }, constantsByCode) : key
+                        )
+                        .value(),
                 },
             };
         } else {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869902c8z

### :memo: Implementation
- [x] Optionally use constant codes to configure formulas for section totals

### :art: Screenshots
<img width="1431" alt="Screenshot 2025-05-09 at 12 53 49" src="https://github.com/user-attachments/assets/fa433ae2-c30f-4fc7-8fb9-e26a501f0d14" />

### :fire: Notes to the tester
- Create constants for each column being used for totals
<img width="797" alt="Screenshot 2025-05-09 at 12 50 34" src="https://github.com/user-attachments/assets/f57eb8c7-d1e6-432a-8ba9-1c16c7b00855" />

- Add translations for each of the constants
<img width="854" alt="Screenshot 2025-05-09 at 12 51 26" src="https://github.com/user-attachments/assets/4a77f890-f071-4a2f-bfb9-347f00f151f1" />

- Update datastore config with the constant code like so:
```
"SECTION_CODE": {
  ...
  "totals": {
    "dataElementsCodes": ["DE_CODE_1", "DE_CODE_2"],
    "formulas": {
      "MAL_COMMUNITY_BASED": {
        "formula": "<%= Math.round((DE_CODE_1/DE_CODE_2)*100) %>",
        "rules": {
          "condition": "< 80",
          "sectionCodes": ["SECTION_TO_HIDE"]
         },
         "type": "sections"
       },
   }
}
```

#869902c8z