### PR TITLE
[feature]: Replace data element name text in view types

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -121,7 +121,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                         backgroundColor={props.section.styles.rows.backgroundColor}
                                         colSpan="2"
                                     >
-                                        <span>{row.deName}</span>
+                                        <DataTableCellRowName html={row.dataElement.htmlText} name={row.deName} />
                                     </CustomDataTableCell>
                                 )}
 

--- a/src/webapp/reports/autogenerated-forms/GridWithPeriods.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithPeriods.tsx
@@ -136,7 +136,10 @@ const PeriodTable: React.FC<PeriodTableProps> = props => {
                                             backgroundColor={props.section.styles.rows.backgroundColor}
                                             colSpan={hasRowsWithSubGroups ? "3" : "2"}
                                         >
-                                            <span>{row.dataElement.name}</span>
+                                            <DataTableCellRowName
+                                                html={row.dataElement.htmlText}
+                                                name={row.dataElement.name}
+                                            />
                                         </CustomDataTableCell>
 
                                         <DataTableDataElementCell

--- a/src/webapp/reports/autogenerated-forms/MatrixGridForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/MatrixGridForm.tsx
@@ -14,6 +14,7 @@ import { MatrixGridViewModel } from "./MatrixGridViewModel";
 import { CustomDataTableCell, CustomDataTableColumnHeader } from "./datatables/CustomDataTables";
 import { DataElementItem } from "./DataElementItem";
 import { checkVisibleRule } from "./DataEntryItem";
+import { DataTableCellRowName } from "./datatables/DataTableCellRowName";
 
 export interface MatrixGridFormProps {
     dataFormInfo: DataFormInfo;
@@ -69,7 +70,7 @@ const MatrixGridForm: React.FC<MatrixGridFormProps> = props => {
                                             backgroundColor={props.section.styles.rows.backgroundColor}
                                             key={dataElement.id}
                                         >
-                                            {dataElement.name}
+                                            <DataTableCellRowName html={dataElement.htmlText} name={dataElement.name} />
                                         </CustomDataTableCell>
                                         <CustomDataTableCell
                                             backgroundColor={props.section.styles.rows.backgroundColor}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699rguvr

### :memo: Implementation
- [x] Replaced span with data table cell row name in grid-with-cat-option-combos, grid-with-periods and matrix-grid view types

### :art: Screenshots
<img width="1433" height="233" alt="Screenshot 2025-07-11 at 14 55 16" src="https://github.com/user-attachments/assets/37e5bca1-5aaa-4e72-b610-1d7532fdb8dd" />


### :fire: Notes to the tester

#8699rguvr