### PR TITLE
[feature]: Rules with multiple conditions based on options

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -299,11 +299,23 @@ export class Dhis2DataFormRepository implements DataFormRepository {
         };
     }
 
-    private getTotalDataElements(rule: ConditionRule, dataElements: Record<string, DataElement>) {
+    private getTotalDataElements(rule: ConditionRule, dataElements: Record<string, DataElement>): Id[] {
         const extractedDataElements =
             rule.type === "option" ? rule.conditions.flatMap(condition => condition.dataElements) : rule.dataElements;
 
-        return extractedDataElements.map(dataElementCode => dataElements[dataElementCode]?.id ?? "");
+        return _(extractedDataElements)
+            .map(dataElementCode => {
+                const dataElement = dataElements[dataElementCode];
+                if (!dataElement) {
+                    console.warn(`Data element not found for code: ${dataElementCode}`);
+                    return;
+                }
+
+                return dataElement.id;
+            })
+            .compact()
+            .uniq()
+            .value();
     }
 
     private getRelatedDataElements(

--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -3,11 +3,11 @@ import _ from "lodash";
 import { Code, getId, Id } from "../../domain/common/entities/Base";
 import { DataElement } from "../../domain/common/entities/DataElement";
 import {
+    ConditionRule,
     DataElementRuleOptions,
     DataElementTotalRule,
     Rule,
     RuleType,
-    SectionRuleOptions,
     SectionTotalRule,
     TotalRules,
 } from "../../domain/common/entities/DataElementRule";
@@ -259,15 +259,14 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                     if (formulaRules.type === "sections") {
                         const { rules, formula } = formulaRules;
 
-                        const sectionTotalsRules = rules as SectionRuleOptions;
                         const relatedDataElements = this.getRelatedDataElements(section, dataElementsByCode, formula);
-                        const sectionIds = _(sectionTotalsRules.sectionCodes)
+                        const sectionIds = _(rules.sectionCodes)
                             .map(sectionCode => sections.find(section => section.code === sectionCode)?.id)
                             .compact()
                             .value();
 
                         return {
-                            condition: sectionTotalsRules.condition,
+                            conditions: [rules.condition],
                             formula: formula,
                             relatedDataElements: relatedDataElements,
                             sections: sectionIds,
@@ -292,11 +291,19 @@ export class Dhis2DataFormRepository implements DataFormRepository {
 
         return {
             type: ruleType,
-            dataElements: rule.dataElements.map(dataElementCode => dataElements[dataElementCode]?.id ?? ""),
+            dataElements: this.getTotalDataElements(rule, dataElements),
             relatedDataElements: relatedDataElements,
-            condition: rule.condition,
+            conditions:
+                rule.type === "option" ? rule.conditions.map(condition => condition.condition) : [rule.condition],
             formula: formula,
         };
+    }
+
+    private getTotalDataElements(rule: ConditionRule, dataElements: Record<string, DataElement>) {
+        const extractedDataElements =
+            rule.type === "option" ? rule.conditions.flatMap(condition => condition.dataElements) : rule.dataElements;
+
+        return extractedDataElements.map(dataElementCode => dataElements[dataElementCode]?.id ?? "");
     }
 
     private getRelatedDataElements(
@@ -355,6 +362,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
         const rulesConfigByDataElement = dataElementsRulesConfig.filter(
             dataElementActionConfig => dataElementActionConfig.id === dataElement.id
         );
+
         const dataElementRules = _(rulesConfigByDataElement)
             .map((dataElementRuleConfig): Maybe<Rule> => {
                 const relatedDataElement = dataElements[dataElementRuleConfig.relatedDataElementId];
@@ -363,6 +371,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
             })
             .compact()
             .value();
+
         return dataElementRules;
     }
 
@@ -377,18 +386,18 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                 if (!dataElementConfig) return undefined;
                 if (!dataElementConfig.rules) return undefined;
 
-                const disabledDataElements = this.getRuleConfigByType(
-                    "disabled",
-                    dataElementConfig,
-                    allDataElements,
-                    dataElement
-                );
-                const visibleDataElements = this.getRuleConfigByType(
-                    "visible",
-                    dataElementConfig,
-                    allDataElements,
-                    dataElement
-                );
+                const disabledDataElements = this.getRuleConfigByType({
+                    ruleType: "disabled",
+                    dataElementConfig: dataElementConfig,
+                    allDataElements: allDataElements,
+                    dataElement: dataElement,
+                });
+                const visibleDataElements = this.getRuleConfigByType({
+                    ruleType: "visible",
+                    dataElementConfig: dataElementConfig,
+                    allDataElements: allDataElements,
+                    dataElement: dataElement,
+                });
 
                 return [...disabledDataElements, ...visibleDataElements];
             })
@@ -396,15 +405,45 @@ export class Dhis2DataFormRepository implements DataFormRepository {
             .value();
     }
 
-    private getRuleConfigByType(
-        ruleType: RuleType,
-        dataElementConfig: DataElementConfig,
-        allDataElements: BasicDataElement[],
-        dataElement: DataElement
-    ) {
+    private getRuleConfigByType(options: RuleConfigParams): RuleConfig[] {
+        const { ruleType, dataElementConfig, allDataElements, dataElement } = options;
+
         const currentConfig = this.getCurrentConfigByRuleType(dataElementConfig, ruleType);
-        return _(currentConfig?.dataElements)
-            .map((dataElementCode): Maybe<RuleConfig> => {
+
+        switch (currentConfig?.type) {
+            case "option": {
+                return currentConfig.conditions.flatMap(condition => {
+                    return _(condition.dataElements)
+                        .map(dataElementCode => {
+                            const dataElementDetails = allDataElements.find(de => de.code === dataElementCode);
+                            if (!dataElementDetails) return undefined;
+                            return {
+                                type: ruleType,
+                                id: dataElementDetails.id,
+                                relatedDataElementId: dataElement.id,
+                                value: condition.condition,
+                            };
+                        })
+                        .compact()
+                        .value();
+                });
+            }
+            default:
+                return this.buildRuleConfigList({
+                    dataElements: currentConfig?.dataElements || [],
+                    ruleType: ruleType,
+                    dataElementConfig: dataElementConfig,
+                    allDataElements: allDataElements,
+                    dataElement: dataElement,
+                });
+        }
+    }
+
+    private buildRuleConfigList(options: RuleConfigParams & { dataElements: string[] }): RuleConfig[] {
+        const { dataElements, ruleType, dataElementConfig, allDataElements, dataElement } = options;
+
+        return _(dataElements)
+            .map(dataElementCode => {
                 const dataElementDetails = allDataElements.find(de => de.code === dataElementCode);
                 if (!dataElementDetails) return undefined;
                 return {
@@ -418,18 +457,21 @@ export class Dhis2DataFormRepository implements DataFormRepository {
             .value();
     }
 
-    private getConditionValue(dataElementConfig: DataElementConfig, ruleType: RuleType) {
-        switch (ruleType) {
-            case "disabled":
-                return dataElementConfig.rules?.disabled?.condition || "";
-            case "visible":
-                return dataElementConfig.rules?.visible?.condition || "";
+    private getConditionValue(dataElementConfig: DataElementConfig, ruleType: RuleType): string {
+        const ruleCondition = dataElementConfig.rules?.[ruleType];
+
+        switch (ruleCondition?.type) {
+            case "option":
+                return ruleCondition.conditions[0]?.condition || "";
             default:
-                throw Error(`Invalid rule type: ${ruleType}`);
+                return ruleCondition?.condition || "";
         }
     }
 
-    private getCurrentConfigByRuleType(dataElementConfigRules: DataElementConfig, type: RuleType) {
+    private getCurrentConfigByRuleType(
+        dataElementConfigRules: DataElementConfig,
+        type: RuleType
+    ): Maybe<ConditionRule> {
         switch (type) {
             case "disabled":
                 return dataElementConfigRules.rules?.disabled;
@@ -561,4 +603,11 @@ type D2Indicator = {
     numerator: string;
     denominator: string;
     indicatorType: { id: string; factor: number };
+};
+
+type RuleConfigParams = {
+    ruleType: RuleType;
+    dataElementConfig: DataElementConfig;
+    allDataElements: BasicDataElement[];
+    dataElement: DataElement;
 };

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -464,31 +464,22 @@ export class Dhis2DataStoreDataForm {
             .compact()
             .value();
 
-        const totalsCodes = _(storeConfig.dataSets)
+        const totalsCodes: string[] = _(storeConfig.dataSets)
             .values()
-            .flatMap(dataSet => _.values(dataSet.sections))
-            .flatMap(section => {
-                const totals = section.totals;
-                if (!totals) return undefined;
+            .flatMap(dataSet =>
+                _.values(dataSet.sections).flatMap((section: { totals: Maybe<TotalsConfig> }) => {
+                    const totals = section.totals;
+                    if (!totals) return undefined;
 
-                const formulaCodes = _(totals.formulas)
-                    .map((_, key) => key)
-                    .compact()
-                    .value();
+                    const formulaCodes = totals.formulas ? Object.keys(totals.formulas) : [];
 
-                switch (true) {
-                    case this.isSectionTotals(totals): {
-                        const sectionTotals = totals as SectionTotals;
-                        return [sectionTotals.texts?.code, ...formulaCodes];
-                    }
-                    default: {
-                        const totalsRecord = totals as Record<string, SectionTotals>;
-                        return _(totalsRecord)
-                            .map(total => total.texts?.code)
-                            .value();
-                    }
-                }
-            })
+                    return this.isSectionTotals(totals)
+                        ? [totals.texts?.code, ...formulaCodes]
+                        : _(totals)
+                              .map(total => total.texts?.code)
+                              .value();
+                })
+            )
             .compact()
             .value();
 

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -9,7 +9,11 @@ import { Period } from "../../domain/common/entities/DataValue";
 import { DescriptionText, Texts, Totals } from "../../domain/common/entities/DataForm";
 import { titleVariant } from "../../domain/common/entities/TitleVariant";
 import { SectionStyle, SectionStyleAttrs } from "../../domain/common/entities/SectionStyle";
-import { DataElementRuleOptions, SectionRuleOptions } from "../../domain/common/entities/DataElementRule";
+import {
+    DataElementRuleOptions,
+    SectionRuleOptions,
+    SingleDERuleOptions,
+} from "../../domain/common/entities/DataElementRule";
 import { ToggleMultiple } from "../../domain/common/entities/ToggleMultiple";
 
 interface DataSetConfig {
@@ -31,7 +35,7 @@ export type TotalsRule = (
       }
     | {
           type: "dataElements";
-          rules?: DataElementRuleOptions;
+          rules?: SingleDERuleOptions;
       }
 ) & { formula: string };
 
@@ -115,9 +119,15 @@ const titleVariantType = oneOf([
     exactly("h6"),
 ]);
 
+const singleConditionDERuleCodec = Codec.interface({ dataElements: array(string), condition: string });
+const multipleConditionDERuleCodec = Codec.interface({
+    type: exactly("option"),
+    conditions: array(singleConditionDERuleCodec),
+});
+
 const dataElementRuleCodec = record(
     oneOf([exactly("visible"), exactly("disabled")]),
-    Codec.interface({ dataElements: array(string), condition: string })
+    oneOf([singleConditionDERuleCodec, multipleConditionDERuleCodec])
 );
 
 const dataElementTotalsRuleCodec = Codec.interface({
@@ -458,18 +468,26 @@ export class Dhis2DataStoreDataForm {
             .values()
             .flatMap(dataSet => _.values(dataSet.sections))
             .flatMap(section => {
-                if (!section.totals) return undefined;
+                const totals = section.totals;
+                if (!totals) return undefined;
 
-                const formulaCodes = _(section.totals.formulas)
+                const formulaCodes = _(totals.formulas)
                     .map((_, key) => key)
                     .compact()
                     .value();
 
-                return this.isSectionTotals(section.totals)
-                    ? [section.totals.texts?.code, ...formulaCodes]
-                    : _(section.totals)
-                          .map(total => total.texts?.code)
-                          .value();
+                switch (true) {
+                    case this.isSectionTotals(totals): {
+                        const sectionTotals = totals as SectionTotals;
+                        return [sectionTotals.texts?.code, ...formulaCodes];
+                    }
+                    default: {
+                        const totalsRecord = totals as Record<string, SectionTotals>;
+                        return _(totalsRecord)
+                            .map(total => total.texts?.code)
+                            .value();
+                    }
+                }
             })
             .compact()
             .value();

--- a/src/domain/common/entities/DataElementRule.ts
+++ b/src/domain/common/entities/DataElementRule.ts
@@ -3,14 +3,29 @@ import { DataElement } from "./DataElement";
 
 export type RuleType = "visible" | "disabled";
 
-export type DataElementRuleOptions = Record<RuleType, { dataElements: Code[]; condition: string }>;
+export type SingleConditionRule = {
+    type?: "single";
+    dataElements: Code[];
+    condition: string;
+};
+
+type MultipleConditionRule = {
+    type: "option";
+    conditions: SingleConditionRule[];
+};
+
+export type ConditionRule = SingleConditionRule | MultipleConditionRule;
+
+export type SingleDERuleOptions = Record<RuleType, ConditionRule>;
+
+export type DataElementRuleOptions = Record<RuleType, ConditionRule>;
 
 export type SectionRuleOptions = { condition: string; sectionCodes: Code[] };
 
 export type Rule = { relatedDataElement: DataElement; type: RuleType; condition: string };
 
 type BaseTotalRule = {
-    condition: string;
+    conditions: string[];
     formula: string;
     relatedDataElements: DataElement[];
 };

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -8,7 +8,7 @@ import { Indicator } from "./Indicator";
 import { SectionStyle } from "./SectionStyle";
 import { titleVariant } from "./TitleVariant";
 import { DataElementToggle } from "./ToggleMultiple";
-import { DataElementRuleOptions, TotalRules } from "./DataElementRule";
+import { SingleDERuleOptions, TotalRules } from "./DataElementRule";
 
 export interface DataForm {
     id: Id;
@@ -54,7 +54,10 @@ export type ViewType = UnionFromValues<typeof DataFormM.viewTypes>;
 
 export type DescriptionText = Maybe<Record<string, Maybe<string>>>;
 
-type FormulaRules = { formula?: string; rules?: DataElementRuleOptions };
+type FormulaRules = {
+    formula?: string;
+    rules?: SingleDERuleOptions;
+};
 export type Totals = FormulaRules & {
     dataElementsCodes: string[];
     formulas: Record<string, TotalsRule> | undefined;

--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -103,19 +103,23 @@ export type UseApplyRulesProps = {
 type UseApplyRulesReturn = { isVisible: boolean; isDisabled: boolean };
 
 export function getValueAndVerifyCondition(
-    rule: Maybe<Rule>,
+    rules: Rule[],
     dataFormInfo: DataFormInfo,
     period: Maybe<string>,
     dataElementTotalRule: Maybe<DataElementTotalRule>
 ): Maybe<boolean> {
-    if (rule) {
-        const dataValue = dataFormInfo.data.values.getOrEmpty(rule.relatedDataElement, {
-            orgUnitId: rule.relatedDataElement.orgUnit || dataFormInfo.orgUnitId,
-            period: period || dataFormInfo.period,
-            categoryOptionComboId: dataFormInfo.categoryOptionComboId,
-        });
+    if (rules.length !== 0) {
+        return rules
+            .map(rule => {
+                const dataValue = dataFormInfo.data.values.getOrEmpty(rule.relatedDataElement, {
+                    orgUnitId: rule.relatedDataElement.orgUnit || dataFormInfo.orgUnitId,
+                    period: period || dataFormInfo.period,
+                    categoryOptionComboId: dataFormInfo.categoryOptionComboId,
+                });
 
-        return verifyConditionByDataValueType(dataValue, rule);
+                return verifyConditionByDataValueType(dataValue, rule);
+            })
+            .some(Boolean);
     } else if (dataElementTotalRule) {
         return evaluateTotalRule(dataElementTotalRule, dataFormInfo, period);
     }
@@ -144,7 +148,9 @@ export function evaluateTotalRule(
     const compiled = _.template(formula, {});
     const totalValue = compiled(_.merge({}, ...totalItems));
 
-    return applyNumericComparison(totalRule, totalValue);
+    return _(totalRule.conditions)
+        .map(rule => applyNumericComparison({ condition: rule }, totalValue))
+        .some();
 }
 
 export function verifyConditionByDataValueType(dataValue: DataValue, rule: { condition: string }): boolean {
@@ -155,6 +161,11 @@ export function verifyConditionByDataValueType(dataValue: DataValue, rule: { con
             return applyNumericComparison(rule, value);
         }
         case "TEXT": {
+            const parsedValue = value && typeof value === "string" ? parseInt(value) : undefined;
+            if (parsedValue !== undefined && !isNaN(parsedValue)) {
+                return rule.condition === String(value);
+            }
+
             const booleanFromTextValue = value !== "Not sure";
             return rule.condition === String(booleanFromTextValue);
         }
@@ -163,7 +174,7 @@ export function verifyConditionByDataValueType(dataValue: DataValue, rule: { con
     }
 }
 
-export function applyNumericComparison(rule: { condition: string }, value: Value) {
+export function applyNumericComparison(rule: { condition: string }, value: Value): boolean {
     const [operator, comparisonValue = ""] = rule.condition.split(" ");
     const numericalValue = parseInt(value as string);
     const numericalComparisonValue = parseInt(comparisonValue);
@@ -205,18 +216,18 @@ export function useApplyRules(props: UseApplyRulesProps): UseApplyRulesReturn {
 
 export function checkVisibleRule(options: UseApplyRulesProps): boolean {
     const { dataElement, dataFormInfo, period, dataElementTotalRules } = options;
-    const visibleRule = dataElement.rules.find(rule => rule.type === "visible");
+    const visibleRules = dataElement.rules.filter(rule => rule.type === "visible");
     const visibleDataElementTotalRule = dataElementTotalRules?.find(rule => rule.type === "visible");
 
-    return getValueAndVerifyCondition(visibleRule, dataFormInfo, period, visibleDataElementTotalRule) ?? true;
+    return getValueAndVerifyCondition(visibleRules, dataFormInfo, period, visibleDataElementTotalRule) ?? true;
 }
 
 export function checkDisabledRule(options: UseApplyRulesProps): boolean {
     const { dataElement, dataFormInfo, period, dataElementTotalRules: totalRules } = options;
-    const disabledRule = dataElement.rules.find(rule => rule.type === "disabled");
-    const disabledDataElementTotalRule = totalRules?.find(rule => rule.type === "visible");
+    const disabledRules = dataElement.rules.filter(rule => rule.type === "disabled");
+    const disabledDataElementTotalRule = totalRules?.find(rule => rule.type === "disabled");
 
-    return getValueAndVerifyCondition(disabledRule, dataFormInfo, period, disabledDataElementTotalRule) ?? false;
+    return getValueAndVerifyCondition(disabledRules, dataFormInfo, period, disabledDataElementTotalRule) ?? false;
 }
 
 const DataEntryItem: React.FC<DataEntryItemProps> = props => {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699rgz5y

### :memo: Implementation
- [x] Add support for rules with conditions based on data element options:
```
"rules": {
  "disabled": {
    "conditions": [
      {
        "condition": "OPTION_CODE_1",
        "dataElements": ["DATA_ELEMENT_1", "DATA_ELEMENT_2"]
      },
      {
        "condition": "OPTION_CODE_2",
        "dataElements": ["DATA_ELEMENT_1"]
      }
    ],
    "type": "option"
}
```
where `OPTION_CODE_1` and `OPTION_CODE_2` are the values of the option set option codes. 

### :art: Screenshots

https://github.com/user-attachments/assets/73cedafa-d8a4-4a99-8572-9ecc690ee314


### :fire: Notes to the tester

#8699rgz5y