### PR TITLE
[feature]: Extend data entry item for number type options

### DIFF
--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -173,7 +173,12 @@ export function verifyConditionByDataValueType(dataValue: DataValue, rule: { con
 }
 
 export function applyNumericComparison(rule: { condition: string }, value: Value): boolean {
-    const [operator, comparisonValue = ""] = rule.condition.split(" ");
+    const [operator, comparisonValue] = rule.condition.split(" ");
+
+    if (!comparisonValue) {
+        return rule.condition === String(value);
+    }
+
     const numericalValue = parseInt(value as string);
     const numericalComparisonValue = parseInt(comparisonValue);
 

--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -175,7 +175,7 @@ export function verifyConditionByDataValueType(dataValue: DataValue, rule: { con
 export function applyNumericComparison(rule: { condition: string }, value: Value): boolean {
     const [operator, comparisonValue] = rule.condition.split(" ");
 
-    if (!comparisonValue) {
+    if (!comparisonValue || !operator) {
         return rule.condition === String(value);
     }
 

--- a/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataEntryItem.tsx
@@ -314,7 +314,7 @@ const DataEntryItem: React.FC<DataEntryItemProps> = props => {
                         options={options.items}
                         onValueChange={notifyChange}
                         state={state}
-                        disabled={disabled}
+                        disabled={isDisabled || disabled}
                     />
                 ) : (
                     <SingleComponent
@@ -322,7 +322,7 @@ const DataEntryItem: React.FC<DataEntryItemProps> = props => {
                         options={options.items}
                         onValueChange={notifyChange}
                         state={state}
-                        disabled={disabled}
+                        disabled={isDisabled || disabled}
                     />
                 );
             default:


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699mq839

### :memo: Implementation
- [x] Optionally disable radio/dropdown component with datastore config
- [x] Apply string comparison for numerical rules when no operator is provided

### :art: Screenshots

https://github.com/user-attachments/assets/790dc512-3b01-4a33-96f4-65a5398f9af1



### :fire: Notes to the tester

#8699mq839