### PR TITLE
[feature]: Disable section using toggle config

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -552,7 +552,7 @@ function getSectionBaseWithToggle(
             if (toggleDataElement) {
                 return {
                     ...base,
-                    toggle: { type: "dataElement", dataElement: toggleDataElement },
+                    toggle: { type: "dataElement", dataElement: toggleDataElement, disabled: toggle.disabled },
                     dataElements: _.without(base.dataElements, toggleDataElement),
                 };
             } else {
@@ -573,6 +573,7 @@ function getSectionBaseWithToggle(
                         type: "dataElementExternal",
                         dataElement: toggleDataElement,
                         condition: toggle.condition || "",
+                        disabled: toggle.disabled,
                     },
                 };
             } else {

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -41,12 +41,24 @@ type SectionTotals = Totals & {
 
 type TotalsConfig = SectionTotals | Record<string, SectionTotals>;
 
+type DataElementToggle = {
+    type: "dataElement";
+    code: Code;
+    disabled: boolean;
+};
+
+type DataElementExternalToggle = {
+    type: "dataElementExternal";
+    code: Code;
+    condition: string | undefined;
+    disabled: boolean;
+};
+
+type Toggle = DataElementToggle | DataElementExternalToggle | { type: "none" };
+
 interface BaseSectionConfig {
     texts: Texts;
-    toggle:
-        | { type: "none" }
-        | { type: "dataElement"; code: Code }
-        | { type: "dataElementExternal"; code: Code; condition: string | undefined };
+    toggle: Toggle;
     tabs: { active: true; order: string | number } | { active: false };
     sortRowsBy: string;
     titleVariant: titleVariant;
@@ -222,6 +234,7 @@ const DataStoreConfigCodec = Codec.interface({
                         type: oneOf([exactly("dataElement"), exactly("dataElementExternal")]),
                         code: string,
                         condition: optional(string),
+                        disabled: optional(string),
                     })
                 ),
                 titleVariant: optional(titleVariantType),
@@ -569,7 +582,7 @@ export class Dhis2DataStoreDataForm {
                 const viewType = sectionConfig.viewType || dataSetDefaultViewType;
 
                 const base: BaseSectionConfig = {
-                    toggle: sectionConfig.toggle || { type: "none" },
+                    toggle: this.getSectionToggle(sectionConfig),
                     texts: {
                         header: this.getTextFromConstants(sectionConfig?.texts?.header, constantsByCode),
                         footer: this.getTextFromConstants(sectionConfig?.texts?.footer, constantsByCode),
@@ -646,6 +659,18 @@ export class Dhis2DataStoreDataForm {
             },
             sections: sections,
         };
+    }
+
+    private getSectionToggle(sectionConfig: {
+        toggle: Maybe<{
+            type: "dataElement" | "dataElementExternal";
+            code: string;
+            condition: Maybe<string>;
+            disabled?: string;
+        }>;
+    }): Toggle {
+        const { toggle } = sectionConfig;
+        return toggle ? { ...toggle, disabled: Boolean(toggle.disabled) || false } : { type: "none" };
     }
 
     private getSectionTotals(

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -234,7 +234,7 @@ const DataStoreConfigCodec = Codec.interface({
                         type: oneOf([exactly("dataElement"), exactly("dataElementExternal")]),
                         code: string,
                         condition: optional(string),
-                        disabled: optional(string),
+                        disabled: optional(boolean),
                     })
                 ),
                 titleVariant: optional(titleVariantType),
@@ -666,7 +666,7 @@ export class Dhis2DataStoreDataForm {
             type: "dataElement" | "dataElementExternal";
             code: string;
             condition: Maybe<string>;
-            disabled?: string;
+            disabled?: boolean;
         }>;
     }): Toggle {
         const { toggle } = sectionConfig;

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -71,8 +71,8 @@ export interface SectionBase {
     dataElements: DataElement[];
     toggle:
         | { type: "none" }
-        | { type: "dataElement"; dataElement: DataElement }
-        | { type: "dataElementExternal"; dataElement: DataElement; condition: string };
+        | { type: "dataElement"; dataElement: DataElement; disabled: boolean }
+        | { type: "dataElementExternal"; dataElement: DataElement; condition: string; disabled: boolean };
     texts: Texts;
     tabs: { active: boolean; order?: string };
     sortRowsBy: string;

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -36,9 +36,13 @@ export const sectionBase: Omit<SectionBase, "id" | "name" | "viewType"> = {
     groupDescriptions: undefined,
     disableComments: false,
     showRowTotals: false,
-    toggleMultiple: [],
+    toggleMultiple: {
+        logicalOperator: "AND",
+        toggleDataElements: [],
+    },
     indicators: [],
     dataElements: [dataElementText],
+    code: "",
 };
 
 export const dataFormBase: Omit<DataForm, "sections"> = {
@@ -49,6 +53,10 @@ export const dataFormBase: Omit<DataForm, "sections"> = {
     texts: defaultTexts,
     options: { dataElements: {} },
     indicators: [],
+    totalRules: {
+        dataElementTotalRules: [],
+        sectionTotalRules: [],
+    },
 };
 
 export const dataValueBase: DataValueBase = {

--- a/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
+++ b/src/webapp/reports/autogenerated-forms/DataTableSection.tsx
@@ -33,6 +33,11 @@ const DataTableSection: React.FC<DataTableProps> = React.memo(props => {
     const { toggle, toggleMultiple } = section;
     const classes = useStyles();
 
+    const isSectionDisabled = React.useMemo(() => {
+        if (toggle.type === "none") return false;
+        return toggle.disabled;
+    }, [toggle]);
+
     const isSectionOpen = React.useMemo(() => {
         if (toggle.type === "dataElement") {
             const dataValue = dataFormInfo.data.values.getOrEmpty(toggle.dataElement, dataFormInfo);
@@ -86,7 +91,7 @@ const DataTableSection: React.FC<DataTableProps> = React.memo(props => {
                 </div>
             )}
 
-            {isSectionOpen && (
+            {(isSectionOpen || isSectionDisabled) && (
                 <>
                     {children}
                     <Html content={section.texts.footer} />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869a9kr3f

### :memo: Implementation
- [x] Optionally disable a section using toggle data element (existing behaviour only hides a section using toggle).
The config for this feature is as follows:
```
"SECTION_CODE": {
  "toggle": {
    "code": "DE_CODE",
    "type": "dataElement",
    "disabled": "true"
  },
},
```
where the `disabled` property is optional.


### :art: Screenshots

https://github.com/user-attachments/assets/9d45c91c-150f-413e-8ce6-b6e1175fc613


### :fire: Notes to the tester

#869a9kr3f