### PR TITLE
fix indicator calculation

### DIFF
--- a/src/webapp/components/IndicatorItem/IndicatorItem.tsx
+++ b/src/webapp/components/IndicatorItem/IndicatorItem.tsx
@@ -38,14 +38,22 @@ export const IndicatorFormulaCell: React.FC<IndicatorFormulaCellProps> = React.m
     const formulaWithValues = _(matcher)
         .map(match => {
             const operand = match.replace(/[#{}]/g, "");
-            const dataElementId = operand.substring(0, operand.indexOf(INDICATOR_SEPARATOR));
-            const cocId = operand.substring(operand.indexOf(INDICATOR_SEPARATOR) + 1, operand.length);
+            const notCombinationFound = !operand.includes(INDICATOR_SEPARATOR);
+
+            const dataElementId = notCombinationFound
+                ? operand
+                : operand.substring(0, operand.indexOf(INDICATOR_SEPARATOR));
+
+            const cocId = notCombinationFound
+                ? undefined
+                : operand.substring(operand.indexOf(INDICATOR_SEPARATOR) + 1, operand.length);
+
             const dataElement = dataFormInfo.metadata.dataForm.dataElements.find(
                 dataElement => dataElement.id === dataElementId
             );
             if (!dataElement) return undefined;
             const dataValue = dataFormInfo.data.values.get(dataElement, {
-                categoryOptionComboId: cocId,
+                categoryOptionComboId: cocId ?? dataElement.cocId ?? dataFormInfo.categoryOptionComboId,
                 orgUnitId: dataFormInfo.orgUnitId,
                 period: period,
             }) as DataValueNumberSingle;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation

An indicator formula can include the dataElement Id and the combination Id:

```shell
#{DE_ID.COC_ID} + #{DE_2_ID.COC_ID}
``` 

For this case the current solution works, but you can omit the combination id in the formula:

```shell
#{DE_ID} + #{DE_2_ID}
``` 

This case was not covered in the current solution. Now the flow is:

- Extract dataElement Id from formula 
- Extract cocId and fallback to current cocId [assigned to the dataElemen](https://github.com/EyeSeeTea/d2-autogen-forms/blob/master/src/domain/common/entities/DataElement.ts#L25)t if not present in formula. 
- Get dataValue associated to dataElement+cocId
- Execute the calculation

### :art: Screenshots

### :fire: Notes to the tester
