### PR TITLE
Fix column name separator to ensure proper dataElement-to-cell mapping

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridIndicatorsCalculatedViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridIndicatorsCalculatedViewModel.ts
@@ -45,7 +45,7 @@ type GroupedTable = {
 };
 
 const separator = " - ";
-const columnSeparator = ".";
+const columnSeparator = "|.|";
 
 type Item = {
     name: string;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/2kppyh6

### :memo: Implementation

### :art: Screenshots

<img width="1188" height="342" alt="Screenshot 2025-09-10 at 08 22 38" src="https://github.com/user-attachments/assets/f458c194-bd96-4e85-8ab9-8da327442df1" />

<img width="1173" height="312" alt="Screenshot 2025-09-10 at 08 24 12" src="https://github.com/user-attachments/assets/0f13ecf3-d095-4d49-9b6b-6097f3241cee" />

### :fire: Notes to the tester

#2kppyh6