### PR TITLE
feat: add TextArea for LONG_TEXT dataElements

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -203,8 +203,9 @@ function getDataElement(dataElement: D2DataElement, config: Dhis2DataStoreDataFo
 
     switch (valueType) {
         case "TEXT":
+            return { type: "TEXT", isLongText: false, related: undefined, ...base };
         case "LONG_TEXT":
-            return { type: "TEXT", related: undefined, ...base };
+            return { type: "TEXT", isLongText: true, related: undefined, ...base };
         case "INTEGER":
         case "INTEGER_NEGATIVE":
         case "INTEGER_POSITIVE":

--- a/src/domain/common/entities/DataElement.ts
+++ b/src/domain/common/entities/DataElement.ts
@@ -48,6 +48,7 @@ export interface DataElementPercentage extends DataElementBase {
 
 export interface DataElementText extends DataElementBase {
     type: "TEXT";
+    isLongText: boolean;
 }
 
 export interface DataElementFile extends DataElementBase {

--- a/src/domain/common/entities/__tests__/dataFixtures.ts
+++ b/src/domain/common/entities/__tests__/dataFixtures.ts
@@ -23,6 +23,7 @@ export const dataElementText: DataElementText = {
     rules: [],
     htmlText: undefined,
     related: undefined,
+    isLongText: false,
 };
 
 export const sectionBase: Omit<SectionBase, "id" | "name" | "viewType"> = {

--- a/src/webapp/reports/autogenerated-forms/widgets/TextWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/TextWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 // @ts-ignore
-import { Input } from "@dhis2/ui";
+import { Input, TextArea } from "@dhis2/ui";
 import { WidgetFeedback } from "../WidgetFeedback";
 import { DataValueTextSingle } from "../../../../domain/common/entities/DataValue";
 import { WidgetProps } from "./WidgetBase";
@@ -30,7 +30,11 @@ const TextWidget: React.FC<TextWidgetProps> = props => {
 
     return (
         <WidgetFeedback state={props.state}>
-            <Input onBlur={notifyChange} onChange={updateState} value={stateValue} disabled={disabled} />
+            {dataValue.dataElement.isLongText ? (
+                <TextArea onBlur={notifyChange} onChange={updateState} value={stateValue} disabled={disabled} />
+            ) : (
+                <Input onBlur={notifyChange} onChange={updateState} value={stateValue} disabled={disabled} />
+            )}
         </WidgetFeedback>
     );
 };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #[869b81y4h](https://app.clickup.com/t/869b81y4h)

### :memo: Implementation

Added `isLongText` prop to `DataElementText`, this prop is used to decide the type of d2 ui component to use in `TextWidget`.
If a DataElement has `LONG_TEXT` type a resizable `TextArea` is used.

### :art: Screenshots
<img width="1403" height="554" alt="image" src="https://github.com/user-attachments/assets/26c46b9a-71d6-4ee5-b148-f2d43e050c96" />

### :fire: Notes to the tester
