### PR TITLE
[feature]: Remove prefix functionality

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -21,6 +21,7 @@ import { Maybe } from "../../utils/ts-utils";
 import { Dhis2DataElement } from "./Dhis2DataElement";
 import {
     DataElementConfig,
+    DataSetConfig,
     Dhis2DataStoreDataForm,
     IndicatorConfig,
     SectionConfig,
@@ -103,9 +104,9 @@ export class Dhis2DataFormRepository implements DataFormRepository {
 
                 const sectionIndicators = this.buildIndicators(section.indicators);
                 const base: SectionBase = {
-                    indicators: this.buildIndicatorsWithConfig(sectionIndicators, config?.indicators),
+                    indicators: this.buildIndicatorsWithConfig(dataSetConfig, sectionIndicators, config?.indicators),
                     id: section.id,
-                    name: section.displayName,
+                    name: removePrefixFromName(dataSetConfig, section.displayName),
                     code: section.code,
                     toggle: { type: "none" },
                     texts: config?.texts || defaultTexts,
@@ -135,6 +136,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                             const deRelated = d2DataElement ? dataElements[d2DataElement.id] : undefined;
                             return {
                                 ...dataElement,
+                                name: removePrefixFromName(dataSetConfig, dataElement.name),
                                 disabledComments: deConfig?.disableComments || false,
                                 related: deRelated
                                     ? { dataElement: deRelated, value: deHideConfig?.value || "" }
@@ -374,16 +376,31 @@ export class Dhis2DataFormRepository implements DataFormRepository {
     }
 
     private buildIndicatorsWithConfig(
+        dataSetConfig: DataSetConfig,
         indicators: Indicator[],
         indicatorsConfig: Maybe<Record<Code, IndicatorConfig>>
     ): Indicator[] {
-        if (!indicatorsConfig) return indicators;
+        if (!indicatorsConfig)
+            return indicators.map(indicator => ({
+                ...indicator,
+                name: removePrefixFromName(dataSetConfig, indicator.name),
+                description: removePrefixFromName(dataSetConfig, indicator.description),
+            }));
+
         return _(indicators)
             .map((indicator): Indicator => {
                 const config = indicatorsConfig[indicator.code];
-                if (!config) return indicator;
+
+                if (!config)
+                    return {
+                        ...indicator,
+                        name: removePrefixFromName(dataSetConfig, indicator.name),
+                        description: removePrefixFromName(dataSetConfig, indicator.description),
+                    };
                 return {
                     ...indicator,
+                    name: removePrefixFromName(dataSetConfig, indicator.name),
+                    description: removePrefixFromName(dataSetConfig, indicator.description),
                     dataElement: config.position
                         ? {
                               code: config.position.dataElement,
@@ -540,6 +557,10 @@ export class Dhis2DataFormRepository implements DataFormRepository {
 
 type Metadata = ReturnType<typeof getMetadataQuery>;
 type D2DataSet = MetadataPick<Metadata>["dataSets"][number];
+
+function removePrefixFromName(dataSetConfig: { removePrefix: Maybe<string> }, name: Maybe<string>): string {
+    return dataSetConfig.removePrefix && name ? name.replace(dataSetConfig.removePrefix, "").trim() : name || "";
+}
 
 function getMetadataQuery(options: { dataSetId: Id }) {
     return {

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -12,7 +12,8 @@ import { DataElementRuleOptions, SectionRuleOptions } from "../../domain/common/
 import { ToggleMultiple } from "../../domain/common/entities/ToggleMultiple";
 import { Period, PeriodType, validatePeriodType } from "../../domain/common/entities/Period";
 
-interface DataSetConfig {
+export interface DataSetConfig {
+    removePrefix: Maybe<string>;
     texts: Texts;
     sections: Record<Id, SectionConfig>;
 }
@@ -308,6 +309,7 @@ const DataStoreConfigCodec = Codec.interface({
 
     dataSets: sectionConfig({
         disableComments: optional(boolean),
+        removePrefix: optional(string),
         viewType: optional(viewType),
         texts: optional(textsCodec),
         showIndex: optional(boolean),
@@ -908,6 +910,7 @@ export class Dhis2DataStoreDataForm {
         const dataSetDefaultViewType = dataSetConfig?.viewType || defaultViewType;
         const constantsByCode = _.keyBy(this.config.constants, getCode);
         const periodType = validatePeriodType(dataSet.periodType);
+        const removePrefix = dataSetConfig?.removePrefix;
 
         const sections = _(dataSetConfig?.sections)
             .toPairs()
@@ -1006,6 +1009,7 @@ export class Dhis2DataStoreDataForm {
                 totals: this.getTextFromConstants(dataSetConfig?.texts?.totals, constantsByCode),
                 name: this.getTextFromConstants(dataSetConfig?.texts?.name, constantsByCode),
             },
+            removePrefix: removePrefix,
             sections: sections,
         };
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bf0xg8

### :memo: Implementation
```
{
    "dataSets": {
        "DATASET_CODE": {
            ...
            "removePrefix": "TUB_",
            ...
        }
    }
}
```

This config will remove the prefix "TUB_" from indicator, dataset and data element names.

### :art: Screenshots
<img width="1440" height="168" alt="Screenshot 2025-12-14 at 21 23 22" src="https://github.com/user-attachments/assets/9912d093-d631-43de-864d-234f096b543f" />
<img width="1440" height="168" alt="Screenshot 2025-12-14 at 21 24 22" src="https://github.com/user-attachments/assets/ab2d70d3-1b58-4c8b-8460-67bba39d348b" />

### :fire: Notes to the tester

#869bf0xg8