### PR TITLE
[fix]: Add minWidth for Single and Multi Select widgets

### DIFF
--- a/src/webapp/reports/autogenerated-forms/WidgetFeedback.tsx
+++ b/src/webapp/reports/autogenerated-forms/WidgetFeedback.tsx
@@ -16,6 +16,11 @@ export const widgetFeedbackStylesByState: Record<WidgetState, CSSProperties> = {
     required: { ...baseStyles, backgroundColor: "red" },
 };
 
-export const WidgetFeedback: React.FC<{ state: WidgetState }> = React.memo(props => {
-    return <div style={widgetFeedbackStylesByState[props.state]}>{props.children}</div>;
+type WidgetFeedbackProps = {
+    state: WidgetState;
+    style?: CSSProperties;
+};
+
+export const WidgetFeedback: React.FC<WidgetFeedbackProps> = React.memo(props => {
+    return <div style={{ ...props.style, ...widgetFeedbackStylesByState[props.state] }}>{props.children}</div>;
 });

--- a/src/webapp/reports/autogenerated-forms/widgets/MultipleSelectWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/MultipleSelectWidget.tsx
@@ -34,7 +34,7 @@ const MultipleSelectWidget: React.FC<MultipleSelectWidgetProps> = props => {
     );
 
     return (
-        <WidgetFeedback state={props.state}>
+        <WidgetFeedback state={props.state} style={{ minWidth: "120px" }}>
             <MultiSelect onChange={notifyChange} selected={selectedValues} disabled={disabled}>
                 {options.map(option => (
                     <MultiSelectOption key={option.value} label={option.name} value={option.value} />

--- a/src/webapp/reports/autogenerated-forms/widgets/SingleSelectWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/SingleSelectWidget.tsx
@@ -31,7 +31,7 @@ const SingleSelectWidget: React.FC<SingleSelectWidgetProps> = props => {
     );
 
     return (
-        <WidgetFeedback state={props.state}>
+        <WidgetFeedback state={props.state} style={{ minWidth: "120px" }}>
             <SingleSelect
                 onChange={notifyChange}
                 selected={selectedValue}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bpqk9h #869bpqk9h

### :memo: Implementation

The objective is to prevent Dropdowns from shrinking too much if other columns are taking the space.

- Add `120px` of minWidth to the `SingleSelect` and `MultiSelect` parent
- Add an optional `style` prop to `WidgetFeedback` to allow for that

**IMPORTANT NOTES**: 
- This will affect all Selects globally
- For some layouts, this change will cause the column to be bigger compared to the previous state (only if there is remaining space)
  - i.e. in Mal WMR -> RDT product type
  - To avoid this, we could set the `flex-basis` of the parent `DataEntryItem`, `valueInput` class. But at that point we don't know the widget type. 

### :art: Screenshots

Before:

<img width="1317" height="253" alt="imagen" src="https://github.com/user-attachments/assets/48c331a6-f535-42d8-a8ac-4e36fb43bfbf" />


After:

<img width="1317" height="253" alt="imagen" src="https://github.com/user-attachments/assets/83ef97e5-758e-41e4-9cdc-ea786ec73a5a" />

### :fire: Notes to the tester
