### PR TITLE
[feat]: Remove prefix from validation result

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -62,6 +62,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
             ),
             showErrorOnCompulsory: dataSet.compulsoryFieldsCompleteOnly,
             periodType: validatePeriodType(dataSet.periodType),
+            removePrefix: dataSetConfig.removePrefix,
         };
     }
 

--- a/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
+++ b/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
@@ -55,7 +55,7 @@ export class ValidateDatasetRulesUseCase {
      * Removes the specified prefix from all words in the description.
      */
     private removePrefixFromDescription(description: string, removePrefix: Maybe<string>): string {
-        if (!removePrefix || !description) return description || "";
+        if (!removePrefix) return description;
         const escapedPrefix = removePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const regex = new RegExp(`\\b${escapedPrefix}`, "g");
         return description.replace(regex, "").trim();

--- a/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
+++ b/src/domain/autogenerated-forms-configurator/usecases/ValidateDatasetRulesUseCase.ts
@@ -14,7 +14,7 @@ export class ValidateDatasetRulesUseCase {
         const rules = await this.getRules(dataSetId, options.cacheKey);
         if (rules.length === 0) return [];
         const results = await this.ruleRepository.validate(dataSetId, options);
-        return this.buildValidationRuleMessages(rules, results);
+        return this.buildValidationRuleMessages(rules, results, options.removePrefix);
     }
 
     private async getRules(dataSetId: Id, cacheKey: number): Promise<ValidationRule[]> {
@@ -27,7 +27,11 @@ export class ValidateDatasetRulesUseCase {
         }
     }
 
-    private buildValidationRuleMessages(rules: ValidationRule[], results: ValidationResult[]): ValidationResult[] {
+    private buildValidationRuleMessages(
+        rules: ValidationRule[],
+        results: ValidationResult[],
+        removePrefix: Maybe<string>
+    ): ValidationResult[] {
         const rulesByKey = _.keyBy(rules, "id");
         return _(results)
             .map((validationResult): Maybe<ValidationResult> => {
@@ -37,17 +41,28 @@ export class ValidateDatasetRulesUseCase {
                     return undefined;
                 }
 
-                return { ...validationResult, message: this.buildRuleMessage(ruleDetails) };
+                return { ...validationResult, message: this.buildRuleMessage(ruleDetails, removePrefix) };
             })
             .compact()
             .value();
     }
 
-    private buildRuleMessage(rule: ValidationRule): string {
-        return rule.message;
+    private buildRuleMessage(rule: ValidationRule, removePrefix: Maybe<string>): string {
+        return this.removePrefixFromDescription(rule.message, removePrefix);
+    }
+
+    /**
+     * Removes the specified prefix from all words in the description.
+     */
+    private removePrefixFromDescription(description: string, removePrefix: Maybe<string>): string {
+        if (!removePrefix || !description) return description || "";
+        const escapedPrefix = removePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const regex = new RegExp(`\\b${escapedPrefix}`, "g");
+        return description.replace(regex, "").trim();
     }
 }
 
 export interface ValidateUseCaseOptions extends ValidateDataSetOptions {
     cacheKey: number;
+    removePrefix?: Maybe<string>;
 }

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -32,6 +32,7 @@ export interface DataForm {
     compulsoryDataValues: CompulsoryDataValue[];
     showErrorOnCompulsory: boolean;
     periodType: PeriodType;
+    removePrefix: Maybe<string>;
 }
 
 export interface Texts {

--- a/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
@@ -501,6 +501,7 @@ function checkValidationRules(options: {
             cacheKey: key,
             period: dataValue.period,
             orgUnitId: dataValue.orgUnitId,
+            removePrefix: dataForm.removePrefix,
         })
         .then(results => {
             const oldIgnoredRules = removeRulesHasChanged(ignoreRules, results);


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bq4azr #869bq4azr

### :memo: Implementation

- Since validation messages come from the backend as a string message, the provided prefix is removed from all the words contained in that message
- Exposed the `removePrefix` option in the `DataForm` entity, and implemented the prefix removal in the `ValidateDatasetRulesUseCase`
  - This has its downsides design-wise but avoids making an extra request to get back the options and reduce risks

### :art: Screenshots
<img width="451" height="515" alt="imagen" src="https://github.com/user-attachments/assets/94976606-4e3f-4d91-ba37-02dbbf1ee190" />

### :fire: Notes to the tester
