### PR TITLE
[feat] Add dataElement rule "enabled"

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ This will create this table:
     Male    |           |           |           |           |         |          |           |           |           |         |
 ```
 
+#### DataElement rules
+
+See [dataelement rules readme](./docs/dataelement_rules.md)
+
 #### DataSet rules
 
 Each dataset entry in `"dataSets"` can optionally contain rules.

--- a/docs/dataelement_rules.md
+++ b/docs/dataelement_rules.md
@@ -1,0 +1,145 @@
+# DataElement Rules
+
+Data elements can have conditional visibility and enabled/disabled states based on the values of other data elements. Rules are configured in the data store under `dataElements.[CODE].rules`.
+
+## Rule Types
+
+-   **`visible`**: Controls whether a data element is shown or hidden in the form
+-   **`disabled`**: Controls whether a data element is read-only (disabled) or editable
+-   **`enabled`**: Controls whether a data element is editable (enabled) - opposite of `disabled` with inverted logic
+
+## Single Condition Rules
+
+The simplest rule format applies rules from a control element to target elements:
+
+```json
+{
+    "dataElements": {
+        "CONTROL_ELEMENT": {
+            "rules": {
+                "visible": {
+                    "dataElements": ["TARGET_ELEMENT_1", "TARGET_ELEMENT_2"],
+                    "condition": "true"
+                }
+            }
+        }
+    }
+}
+```
+
+This makes `TARGET_ELEMENT_1` and `TARGET_ELEMENT_2` visible only when `CONTROL_ELEMENT` has the value `"true"`.
+
+**Note**: The element you configure (the key) is the **control element** whose value is checked. The elements in the `dataElements` array are the **target elements** that get affected by the rule.
+
+## Multiple Condition Rules
+
+For more complex scenarios, you can use multiple conditions with OR logic (if ANY condition matches, the rule applies):
+
+```json
+{
+    "dataElements": {
+        "STATUS_ELEMENT": {
+            "rules": {
+                "disabled": {
+                    "type": "option",
+                    "conditions": [
+                        { "dataElements": ["TARGET_ELEMENT_1", "TARGET_ELEMENT_2"], "condition": "approved" },
+                        { "dataElements": ["TARGET_ELEMENT_1"], "condition": "locked" }
+                    ]
+                }
+            }
+        }
+    }
+}
+```
+
+This disables `TARGET_ELEMENT_1` when `STATUS_ELEMENT` is either `"approved"` OR `"locked"`, and disables `TARGET_ELEMENT_2` when `STATUS_ELEMENT` is `"approved"`.
+
+## Condition Formats
+
+Conditions can be simple equality checks or numeric comparisons:
+
+-   **Equality**: `"condition": "value"` - Matches exact string value
+-   **Boolean values**: `"condition": "true"` or `"condition": "false"`
+-   **Numeric comparisons**:
+    -   `"condition": "> 10"` - Greater than
+    -   `"condition": "< 5"` - Less than
+    -   `"condition": ">= 100"` - Greater than or equal to
+    -   `"condition": "<= 50"` - Less than or equal to
+    -   `"condition": "== 0"` - Equal to
+    -   `"condition": "!= 0"` - Not equal to
+
+## Multiple Target Data Elements
+
+You can apply rules to multiple target elements at once:
+
+```json
+{
+    "dataElements": {
+        "CONTROL_ELEMENT": {
+            "rules": {
+                "visible": {
+                    "dataElements": ["TARGET_A", "TARGET_B", "TARGET_C"],
+                    "condition": "true"
+                }
+            }
+        }
+    }
+}
+```
+
+This makes all three target elements (TARGET_A, TARGET_B, and TARGET_C) visible when `CONTROL_ELEMENT` is `"true"`.
+
+## The `enabled` Rule (Positive Logic)
+
+**Use Case**: Instead of listing all cases when an element should be disabled, you specify when it should be enabled.
+
+**Example - Before (using `disabled` with multiple conditions)**:
+
+```json
+{
+    "dataElements": {
+        "BOOLEAN_DE": {
+            "rules": {
+                "disabled": {
+                    "type": "option",
+                    "conditions": [
+                        { "dataElements": ["TARGET_ELEMENT"], "condition": "false" },
+                        { "dataElements": ["TARGET_ELEMENT"], "condition": "undefined" }
+                    ]
+                }
+            }
+        }
+    }
+}
+```
+
+**Example - After (using `enabled`)**:
+
+```json
+{
+    "dataElements": {
+        "BOOLEAN_DE": {
+            "rules": {
+                "enabled": {
+                    "dataElements": ["TARGET_ELEMENT"],
+                    "condition": "true"
+                }
+            }
+        }
+    }
+}
+```
+
+**How it works**:
+
+-   **`enabled` rules**: Element is editable if ANY rule matches. If no rules match, the element is **disabled**.
+-   **Priority**: `disabled` rules take precedence over `enabled` rules
+-   **Default behavior**: If neither `enabled` nor `disabled` rules exist, the element is enabled by default
+
+**Rule Precedence**:
+
+1.  If ANY `disabled` rule matches → Element is **disabled** (highest priority)
+2.  Else, if ANY `enabled` rule matches → Element is **enabled**
+3.  Else, if `enabled` rules exist but none match → Element is **disabled**
+4.  Else (no `enabled` or `disabled` rules) → Element is **enabled** (default)

--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -328,8 +328,15 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                             dataElementsByCode,
                             formula
                         );
+                        const enabledTotalRule = this.getTotalRuleByRuleType(
+                            "enabled",
+                            rules,
+                            section,
+                            dataElementsByCode,
+                            formula
+                        );
 
-                        return visibleTotalRule || disabledTotalRule;
+                        return visibleTotalRule || disabledTotalRule || enabledTotalRule;
                     }
                 })
                 .compact()
@@ -520,8 +527,14 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                     allDataElements: allDataElements,
                     dataElement: dataElement,
                 });
+                const enabledDataElements = this.getRuleConfigByType({
+                    ruleType: "enabled",
+                    dataElementConfig: dataElementConfig,
+                    allDataElements: allDataElements,
+                    dataElement: dataElement,
+                });
 
-                return [...disabledDataElements, ...visibleDataElements];
+                return [...disabledDataElements, ...visibleDataElements, ...enabledDataElements];
             })
             .compact()
             .value();
@@ -599,6 +612,8 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                 return dataElementConfigRules.rules?.disabled;
             case "visible":
                 return dataElementConfigRules.rules?.visible;
+            case "enabled":
+                return dataElementConfigRules.rules?.enabled;
             default:
                 return undefined;
         }

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -254,7 +254,7 @@ const multipleConditionDERuleCodec = Codec.interface({
 });
 
 const dataElementRuleCodec = record(
-    oneOf([exactly("visible"), exactly("disabled")]),
+    oneOf([exactly("visible"), exactly("disabled"), exactly("enabled")]),
     oneOf([singleConditionDERuleCodec, multipleConditionDERuleCodec])
 );
 

--- a/src/data/common/RulesFormula.ts
+++ b/src/data/common/RulesFormula.ts
@@ -2,7 +2,7 @@ import { array, Codec, exactly, oneOf, record, string, GetType } from "purify-ts
 import { Code } from "../../domain/common/entities/Base";
 
 export const rulesFormulaCodec = record(
-    oneOf([exactly("visible"), exactly("disabled")]),
+    oneOf([exactly("visible"), exactly("disabled"), exactly("enabled")]),
     Codec.interface({
         formula: Codec.interface({ value: string, condition: string }),
         dataElements: array(Codec.interface({ code: string })),
@@ -14,6 +14,7 @@ export type FromRulesFormulaCodec = GetType<typeof rulesFormulaCodec>;
 export type RulesFormula = {
     visible?: FormulaDetails;
     disabled?: FormulaDetails;
+    enabled?: FormulaDetails;
 };
 export type ColumnsRules = Record<string, RulesFormula>;
 

--- a/src/domain/common/entities/DataElementRule.ts
+++ b/src/domain/common/entities/DataElementRule.ts
@@ -1,7 +1,7 @@
 import { Code } from "./Base";
 import { DataElement } from "./DataElement";
 
-export type RuleType = "visible" | "disabled";
+export type RuleType = "visible" | "disabled" | "enabled";
 
 export type SingleConditionRule = {
     type?: "single";

--- a/src/webapp/reports/autogenerated-forms-configurator/schemas/dataElements/dataElement.ts
+++ b/src/webapp/reports/autogenerated-forms-configurator/schemas/dataElements/dataElement.ts
@@ -27,6 +27,18 @@ export const dataElementRulesSchema = (
                     dataElements: { type: "array" },
                 },
             }),
+            enabled: defaultObjectProperties({
+                properties: {
+                    condition: { type: "string" },
+                    dataElements: {
+                        items: {
+                            type: "string",
+                            enum: dataElements.map(dataElement => dataElement.dataElementCode),
+                        },
+                        type: "array",
+                    },
+                },
+            }),
         },
     });
 

--- a/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
@@ -25,10 +25,19 @@ export function useApplyRules(props: UseApplyRulesProps): UseApplyRulesReturn {
     if (dataElement.rules.length === 0 && dataElementTotalRules.length === 0)
         return { isDisabled: false, isVisible: true };
 
+    // disabled rules take precedence over enabled rules
     const disabledValue = checkDisabledRule({ dataElement, dataFormInfo, period });
+    if (disabledValue) {
+        const visibleValue = checkVisibleRule({ dataElement, dataFormInfo, period, dataElementTotalRules });
+        return { isDisabled: true, isVisible: visibleValue };
+    }
+
+    const enabledValue = checkEnabledRule({ dataElement, dataFormInfo, period });
+    const isDisabled = enabledValue !== undefined ? !enabledValue : false;
+
     const visibleValue = checkVisibleRule({ dataElement, dataFormInfo, period, dataElementTotalRules });
 
-    return { isDisabled: disabledValue, isVisible: visibleValue };
+    return { isDisabled, isVisible: visibleValue };
 }
 
 export function checkVisibleRule(options: UseApplyRulesProps): boolean {
@@ -45,6 +54,15 @@ function checkDisabledRule(options: UseApplyRulesProps): boolean {
     const disabledDataElementTotalRule = totalRules?.find(rule => rule.type === "disabled");
 
     return getValueAndVerifyCondition(disabledRules, dataFormInfo, period, disabledDataElementTotalRule) ?? false;
+}
+
+function checkEnabledRule(options: UseApplyRulesProps): Maybe<boolean> {
+    const { dataElement, dataFormInfo, period, dataElementTotalRules: totalRules } = options;
+    const enabledRules = dataElement.rules.filter(rule => rule.type === "enabled");
+    const enabledDataElementTotalRule = totalRules?.find(rule => rule.type === "enabled");
+
+    if (enabledRules.length === 0 && !enabledDataElementTotalRule) return undefined;
+    return getValueAndVerifyCondition(enabledRules, dataFormInfo, period, enabledDataElementTotalRule) ?? false;
 }
 
 function getValueAndVerifyCondition(


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related https://app.clickup.com/t/869brj0wz #869brj0wz

### :memo: Implementation

- Add a new dataElement rule `enabled`
- The `disabled` rule still has precedence over `enabled`
- This simplifies configuration when we want to hava a dataElement enabled only if certain condition is met

### :art: Screenshots

### :fire: Notes to the tester
