### PR TITLE
[fix]: align indicators in tableForms whith period offset

### DIFF
--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -72,7 +72,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "before") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -109,7 +109,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "after") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -145,7 +145,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                             <RowIndicatorItem
                                 key={`parent_${indicator.id}`}
                                 indicator={indicator}
-                                colSpan="0"
+                                colSpan={section.dataEntryPeriod ? "2" : "1"}
                                 dataFormInfo={dataFormInfo}
                                 periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                             />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bwm272 #869bwm272

### :memo: Implementation

When an indicator was shown in a `TableForm` with a period offset, the input would show under period. This adds an extra `colSpan` in case there is a period offset, so that the input is aligned.

### :art: Screenshots

<img width="1238" height="180" alt="imagen" src="https://github.com/user-attachments/assets/bc4263fa-28ab-4db4-bfac-7d9f67120de0" />


### :fire: Notes to the tester
