### PR TITLE
Fix/tableform indicator period offset (copy from PR #128)

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridForm.tsx
@@ -48,9 +48,9 @@ const GridForm: React.FC<GridFormProps> = props => {
     const grid = React.useMemo(() => GridViewModel.get(section, dataFormInfo, "grid"), [section, dataFormInfo]);
     const classes = useStyles();
 
-    const showIndicatorsAfter = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
-    const showIndicatorsBefore = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
-    const nonDirectionalIndicators = grid.indicators.filter(
+    const showIndicatorsAfter = section.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
+    const showIndicatorsBefore = section.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
+    const nonDirectionalIndicators = section.indicators.filter(
         indicator => !checkIndicatorDirection(indicator, "before") && !checkIndicatorDirection(indicator, "after")
     );
 
@@ -189,7 +189,7 @@ const GridForm: React.FC<GridFormProps> = props => {
                                         </CustomDataTableCell>
                                     )}
 
-                                    {getFilteredIndicators(grid.indicators, row, "before").map(
+                                    {getFilteredIndicators(section.indicators, row, "before").map(
                                         indicator =>
                                             indicator && (
                                                 <IndicatorItem
@@ -227,7 +227,7 @@ const GridForm: React.FC<GridFormProps> = props => {
                                         )
                                     )}
 
-                                    {getFilteredIndicators(grid.indicators, row, "after").map(
+                                    {getFilteredIndicators(section.indicators, row, "after").map(
                                         indicator =>
                                             indicator && (
                                                 <IndicatorItem

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -57,9 +57,9 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
     );
 
     const showRowTotals = section.showRowTotals;
-    const showIndicatorsAfter = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
-    const showIndicatorsBefore = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
-    const nonDirectionalIndicators = grid.indicators.filter(
+    const showIndicatorsAfter = section.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
+    const showIndicatorsBefore = section.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
+    const nonDirectionalIndicators = section.indicators.filter(
         indicator => !checkIndicatorDirection(indicator, "before") && !checkIndicatorDirection(indicator, "after")
     );
 
@@ -147,7 +147,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                     </CustomDataTableCell>
                                 )}
 
-                                {getFilteredIndicators(grid.indicators, row, "before").map(
+                                {getFilteredIndicators(section.indicators, row, "before").map(
                                     indicator =>
                                         indicator && (
                                             <IndicatorItem
@@ -189,7 +189,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                     );
                                 })}
 
-                                {getFilteredIndicators(grid.indicators, row, "after").map(
+                                {getFilteredIndicators(section.indicators, row, "after").map(
                                     indicator =>
                                         indicator && (
                                             <IndicatorItem

--- a/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
+++ b/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
@@ -188,6 +188,21 @@ function isTabHeader(order: Maybe<string>) {
     return isNaN(secondaryTabIndex) || secondaryTabIndex === 0 || secondaryTabIndex === 1;
 }
 
+function tabHeaderShouldShowIndex(section: Section, sections: Section[]): boolean {
+    if (section.showIndex) return true;
+    if (!section.tabs.order) return false;
+
+    const [rawPrimaryIndex] = getTabIndices(section.tabs.order);
+    const hasSiblingsWithShowIndex = sections.some(s => {
+        const siblingOrder = s.tabs.order;
+        if (!siblingOrder) return false;
+        const [siblingPrimaryIndex] = getTabIndices(siblingOrder);
+        return siblingPrimaryIndex === rawPrimaryIndex && s.showIndex;
+    });
+
+    return hasSiblingsWithShowIndex;
+}
+
 const AutoFormComponent = React.memo(TypeSwitch);
 
 const TabPanel: React.FC<TabProps> = React.memo(props => {
@@ -320,8 +335,10 @@ const SectionsTabs: React.FC<TabPanelProps> = React.memo(props => {
                         if (isTabHeader(order)) {
                             const sectionTabLabel = section.texts.tabLabel || section.name;
                             const [primaryTabIndex] = getTabIndices(section.tabs.order, sections, section.showIndex);
+                            const shouldShowIndex = tabHeaderShouldShowIndex(section, sections);
+
                             const tabLabel =
-                                section.showIndex && primaryTabIndex !== -1
+                                shouldShowIndex && primaryTabIndex !== -1
                                     ? `${primaryTabIndex + 1} - ${sectionTabLabel}`
                                     : sectionTabLabel;
 

--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -72,7 +72,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "before") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -109,7 +109,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "after") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -145,7 +145,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                             <RowIndicatorItem
                                 key={`parent_${indicator.id}`}
                                 indicator={indicator}
-                                colSpan="0"
+                                colSpan={section.dataEntryPeriod ? "2" : "1"}
                                 dataFormInfo={dataFormInfo}
                                 periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                             />


### PR DESCRIPTION
Originally from @MatiasArriola 

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bwm272 #869bwm272

### :memo: Implementation

When an indicator was shown in a `TableForm` with a period offset, the input would show under period. This adds an extra `colSpan` in case there is a period offset, so that the input is aligned.

### :art: Screenshots

<img width="1238" height="180" alt="imagen" src="https://github.com/user-attachments/assets/bc4263fa-28ab-4db4-bfac-7d9f67120de0" />


### :fire: Notes to the tester
