### PR TITLE
[fix]: show tab index if any sibling section has showIndex (copy from #126)

### DIFF
--- a/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
+++ b/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
@@ -188,6 +188,21 @@ function isTabHeader(order: Maybe<string>) {
     return isNaN(secondaryTabIndex) || secondaryTabIndex === 0 || secondaryTabIndex === 1;
 }
 
+function tabHeaderShouldShowIndex(section: Section, sections: Section[]): boolean {
+    if (section.showIndex) return true;
+    if (!section.tabs.order) return false;
+
+    const [rawPrimaryIndex] = getTabIndices(section.tabs.order);
+    const hasSiblingsWithShowIndex = sections.some(s => {
+        const siblingOrder = s.tabs.order;
+        if (!siblingOrder) return false;
+        const [siblingPrimaryIndex] = getTabIndices(siblingOrder);
+        return siblingPrimaryIndex === rawPrimaryIndex && s.showIndex;
+    });
+
+    return hasSiblingsWithShowIndex;
+}
+
 const AutoFormComponent = React.memo(TypeSwitch);
 
 const TabPanel: React.FC<TabProps> = React.memo(props => {
@@ -320,8 +335,10 @@ const SectionsTabs: React.FC<TabPanelProps> = React.memo(props => {
                         if (isTabHeader(order)) {
                             const sectionTabLabel = section.texts.tabLabel || section.name;
                             const [primaryTabIndex] = getTabIndices(section.tabs.order, sections, section.showIndex);
+                            const shouldShowIndex = tabHeaderShouldShowIndex(section, sections);
+
                             const tabLabel =
-                                section.showIndex && primaryTabIndex !== -1
+                                shouldShowIndex && primaryTabIndex !== -1
                                     ? `${primaryTabIndex + 1} - ${sectionTabLabel}`
                                     : sectionTabLabel;
 


### PR DESCRIPTION
Originally from @MatiasArriola 

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869brgqw8 #869brgqw8

### :memo: Implementation

- Previously, the tab number would only show if the "tab section" had the configuration `showIndex: true`. With this change, it also shows the number if any section belonging to the same tab, has the `showIndex` property.

This is to fix the case where the first section of a tab is decorative and has showIndex false, but we still want to show the tab index.

Please review if this workaround is valid. 

Another alternative I thought about was to add an extra configuration option to `[section].tabs`, because here the same `[section].showIndex` property  is indicating both: "include the index in the tab name" and "include the index for section indexing (subtitles)".

### :art: Screenshots

### :fire: Notes to the tester
