### PR TITLE
[fix]: missing indicators (copy from #125)

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridForm.tsx
@@ -48,9 +48,9 @@ const GridForm: React.FC<GridFormProps> = props => {
     const grid = React.useMemo(() => GridViewModel.get(section, dataFormInfo, "grid"), [section, dataFormInfo]);
     const classes = useStyles();
 
-    const showIndicatorsAfter = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
-    const showIndicatorsBefore = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
-    const nonDirectionalIndicators = grid.indicators.filter(
+    const showIndicatorsAfter = section.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
+    const showIndicatorsBefore = section.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
+    const nonDirectionalIndicators = section.indicators.filter(
         indicator => !checkIndicatorDirection(indicator, "before") && !checkIndicatorDirection(indicator, "after")
     );
 
@@ -189,7 +189,7 @@ const GridForm: React.FC<GridFormProps> = props => {
                                         </CustomDataTableCell>
                                     )}
 
-                                    {getFilteredIndicators(grid.indicators, row, "before").map(
+                                    {getFilteredIndicators(section.indicators, row, "before").map(
                                         indicator =>
                                             indicator && (
                                                 <IndicatorItem
@@ -227,7 +227,7 @@ const GridForm: React.FC<GridFormProps> = props => {
                                         )
                                     )}
 
-                                    {getFilteredIndicators(grid.indicators, row, "after").map(
+                                    {getFilteredIndicators(section.indicators, row, "after").map(
                                         indicator =>
                                             indicator && (
                                                 <IndicatorItem

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -57,9 +57,9 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
     );
 
     const showRowTotals = section.showRowTotals;
-    const showIndicatorsAfter = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
-    const showIndicatorsBefore = grid.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
-    const nonDirectionalIndicators = grid.indicators.filter(
+    const showIndicatorsAfter = section.indicators.some(indicator => checkIndicatorDirection(indicator, "after"));
+    const showIndicatorsBefore = section.indicators.some(indicator => checkIndicatorDirection(indicator, "before"));
+    const nonDirectionalIndicators = section.indicators.filter(
         indicator => !checkIndicatorDirection(indicator, "before") && !checkIndicatorDirection(indicator, "after")
     );
 
@@ -147,7 +147,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                     </CustomDataTableCell>
                                 )}
 
-                                {getFilteredIndicators(grid.indicators, row, "before").map(
+                                {getFilteredIndicators(section.indicators, row, "before").map(
                                     indicator =>
                                         indicator && (
                                             <IndicatorItem
@@ -189,7 +189,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                                     );
                                 })}
 
-                                {getFilteredIndicators(grid.indicators, row, "after").map(
+                                {getFilteredIndicators(section.indicators, row, "after").map(
                                     indicator =>
                                         indicator && (
                                             <IndicatorItem


### PR DESCRIPTION
Originally from @MatiasArriola 

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bw4gej #869bw4gej

### :memo: Implementation

- revert changes made in #122 back to using `section` instead of `grid` for indicators, which was causing indicators to not be rendered

### :art: Screenshots

### :fire: Notes to the tester
