### PR TITLE
fix: align indicators adding colspan offset depending on period

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -216,7 +216,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                         <RowIndicatorItem
                             key={`parent_${indicator.id}`}
                             indicator={indicator}
-                            colSpan="2"
+                            colSpan={grid.periods.length > 0 ? "3" : "2"}
                             dataFormInfo={dataFormInfo}
                             periods={[dataFormInfo.period]}
                         />

--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -72,7 +72,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "before") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -109,7 +109,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                 {dataElement.indicator && checkIndicatorDirection(dataElement.indicator, "after") && (
                                     <RowIndicatorItem
                                         indicator={dataElement.indicator}
-                                        colSpan="0"
+                                        colSpan={section.dataEntryPeriod ? "2" : "1"}
                                         dataFormInfo={dataFormInfo}
                                         periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                                     />
@@ -145,7 +145,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                             <RowIndicatorItem
                                 key={`parent_${indicator.id}`}
                                 indicator={indicator}
-                                colSpan="0"
+                                colSpan={section.dataEntryPeriod ? "2" : "1"}
                                 dataFormInfo={dataFormInfo}
                                 periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
                             />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bwm272 #869bwm272

### :memo: Implementation

When an indicator was shown in a `TableForm` with a period offset, the input would show under period. This adds an extra colSpan in case there is a period offset, so that the input is aligned.

The same for `GridWithCatOptionCombos`.

### :art: Screenshots

### :fire: Notes to the tester
