### PR TITLE
[feature]: implement columnsConfig visibility for GridWithCatOptionCombos

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
@@ -10,6 +10,7 @@ import { getIndexedLabel } from "./DataTableSection";
 import { Period } from "../../../domain/common/entities/Period";
 import { isToggleMultipleDeDisabled } from "../../../domain/common/entities/ToggleMultiple";
 import { getIndexedIndicator } from "./indicatorIndexing";
+import { calculateFormula } from "./datatables/InputFormula";
 
 export interface Grid {
     id: string;
@@ -37,6 +38,7 @@ interface Column {
     name: string;
     dataElements: DataElement[];
     description?: string;
+    isVisible: boolean;
 }
 
 type Row = {
@@ -179,14 +181,17 @@ export class GridWithCatOptionCombosViewModel {
                 .flatMap(({ rows }) => subsection.dataElements.filter(de => rows.some(row => row.name === de.name)))
                 .map(de => ({ ...de, disabled: isToggleMultipleDeDisabled(section, de, orgUnitCode) }));
 
-            return {
+            const column: Column = {
                 name: subsection.name,
                 dataElements: columnDataElements,
                 description: columnDescription,
+                isVisible: true,
             };
+            return GridWithCatOptionCombosViewModel.applyColumnVisibility(section, column, dataFormInfo, subsection);
         });
 
-        return _.orderBy(subsectionColumns, [section.sortRowsBy ? section.sortRowsBy : ""]);
+        const visibleColumns = subsectionColumns.filter(column => column.isVisible);
+        return _.orderBy(visibleColumns, [section.sortRowsBy ? section.sortRowsBy : ""]);
     }
 
     private static getSummary(section: SectionWithPeriods, columns: Column[], dataFormInfo: DataFormInfo): Summary[] {
@@ -241,6 +246,58 @@ export class GridWithCatOptionCombosViewModel {
             })
             .value();
     }
+
+    /**
+     * Returns the column with the visible property applied based on the section's columnsConfig.
+     * columnConfig key can be either "dataElementCode||categoryOptionCode" or "categoryOptionCode".
+     */
+    private static applyColumnVisibility(
+        section: SectionWithPeriods,
+        column: Column,
+        dataFormInfo: DataFormInfo,
+        subsection: SubSectionGrid
+    ): Column {
+        if (!section.columnsConfig) return column;
+
+        const applyVisibilityRule = (configKey: string): Maybe<Column> => {
+            const visibleRule = section.columnsConfig?.[configKey]?.rules?.visible;
+            if (!visibleRule) return undefined;
+
+            const dataElementCodesForFormula = _(visibleRule.dataElements)
+                .map(de => de.code)
+                .compact()
+                .value();
+
+            const value = calculateFormula({
+                dataElementCodes: dataElementCodesForFormula,
+                dataFormInfo,
+                formula: visibleRule.formula.value ?? "",
+                period: dataFormInfo.period,
+            });
+
+            const isVisible = value === visibleRule.formula.condition;
+            return { ...column, isVisible };
+        };
+
+        const categoryOptionCode = subsection.code || "";
+        const columnWithCatOptionVisibility = applyVisibilityRule(categoryOptionCode);
+        if (columnWithCatOptionVisibility) return columnWithCatOptionVisibility;
+
+        const dataElementConfigKeys = subsection.dataElements
+            .map(de => `${de.code}${COLUMNS_CONFIG_SEPARATOR}${categoryOptionCode}`)
+            .filter(key => key in (section.columnsConfig || {}));
+
+        const isVisibleForAllRows = dataElementConfigKeys.every(configKey => {
+            const columnWithDeVisibility = applyVisibilityRule(configKey);
+            return columnWithDeVisibility ? columnWithDeVisibility.isVisible : true;
+        });
+
+        if (!isVisibleForAllRows) {
+            return { ...column, isVisible: false };
+        }
+
+        return column;
+    }
 }
 
 export type Summary = { cells: CellTotal[]; cellName: string };
@@ -259,11 +316,7 @@ function getDataElementLabel(
     return getIndexedLabel(section, dataFormInfo, deName, deIndex);
 }
 
-function getDataElementHtmlText(
-    dataElement: DataElement,
-    section: SectionWithPeriods,
-    dataFormInfo: DataFormInfo
-) {
+function getDataElementHtmlText(dataElement: DataElement, section: SectionWithPeriods, dataFormInfo: DataFormInfo) {
     if (!dataElement.htmlText) return undefined;
     return getDataElementLabel(dataElement, section, dataFormInfo, dataElement.htmlText);
 }
@@ -286,3 +339,5 @@ export function getFilteredIndicators(
             : undefined
     );
 }
+
+const COLUMNS_CONFIG_SEPARATOR = "||";

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
@@ -249,7 +249,8 @@ export class GridWithCatOptionCombosViewModel {
 
     /**
      * Returns the column with the visible property applied based on the section's columnsConfig.
-     * columnConfig key can be either "dataElementCode||categoryOptionCode" or "categoryOptionCode".
+     * columnConfig key can be either "categoryOptionCode" or "dataElementCode||categoryOptionCode".
+     * If both "categoryOptionCode" and "dataElementCode||categoryOptionCode" are defined, "categoryOptionCode" takes precendence
      */
     private static applyColumnVisibility(
         section: SectionWithPeriods,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bw6wuh #869bw6wuh

### :memo: Implementation

- Added support for column visibility config for viewType `grid-with-cat-option-combos`
  - the columnsConfig key can either be the category option code or "{dataElementCode}||{catOptionCode}"
  - if multiple visible rules are provided for the same categoryOption, the column will be visible only if all rules evaluate to true
  - filters out invisible columns at the view model level
  
This feature was already implemented for `grid` and `grid-disaggregated-cocs`

### :art: Screenshots

### :fire: Notes to the tester
