### PR TITLE
[fix]: add z-index to AlertRules

### DIFF
--- a/src/webapp/components/alert-rule/AlertRules.tsx
+++ b/src/webapp/components/alert-rule/AlertRules.tsx
@@ -58,6 +58,7 @@ const AlertContainer = styled.div`
     max-width: 400px;
     position: fixed;
     right: 15px;
+    z-index: 1;
 `;
 
 const MarkAllAsReadButton = styled.div`


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes N/A

### :memo: Implementation

Added `z-index` to `AlertRules` so form controls do not appear above them. 

Originally I've included this as part of #139, but reverted it because it was wrong, and took the opportunity to add this  as a separate PR instead.

### :art: Screenshots

Before:
<img width="442" height="138" alt="imagen" src="https://github.com/user-attachments/assets/1cd9a003-f4e5-4d39-91dc-50357c6a1948" />


After:
<img width="442" height="138" alt="imagen" src="https://github.com/user-attachments/assets/139f9721-5dcf-4dfb-89b5-374c8855df04" />


### :fire: Notes to the tester
