### PR TITLE
[feature]: empty values in totals calculations, strict flag

### DIFF
--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -302,6 +302,7 @@ const totalsType = Codec.interface({
     formula: optional(string),
     rules: optional(dataElementRuleCodec),
     texts: optional(Codec.interface({ name: optional(string), code: optional(string) })),
+    strict: optional(boolean),
 });
 
 const stylesType = Codec.interface({

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -83,6 +83,7 @@ type FormulaRules = {
 export type Totals = FormulaRules & {
     dataElementsCodes: string[];
     formulas: Record<string, TotalsRule> | undefined;
+    strict?: boolean;
 };
 
 export interface SectionBase {

--- a/src/webapp/reports/autogenerated-forms/GridFormViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridFormViewModel.ts
@@ -352,6 +352,7 @@ export class GridViewModel {
                                     columnName: key,
                                     formula: sectionTotal.formula || "",
                                     items: this.getColumnWithDataElements(selectedDataElements, key),
+                                    strict: sectionTotal.strict,
                                 },
                             ],
                         };
@@ -374,6 +375,7 @@ export class GridViewModel {
                                 columnName: column.name,
                                 formula: getFormulaByColumnName(section, column.name) || sectionTotal.formula || "",
                                 items: columnWithDataElements,
+                                strict: sectionTotal.strict,
                             };
                         });
 

--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombosViewModel.ts
@@ -239,6 +239,7 @@ export class GridWithCatOptionCombosViewModel {
                         columnName: column.name,
                         formula: getFormulaByColumnName(section, column.name) || sectionTotal.formula || "",
                         items: columnWithDataElements,
+                        strict: sectionTotal.strict,
                     };
                 });
 
@@ -329,7 +330,7 @@ export class GridWithCatOptionCombosViewModel {
 }
 
 export type Summary = { cells: CellTotal[]; cellName: string };
-export type CellTotal = { formula: string; columnName: string; items: TotalItem[] };
+export type CellTotal = { formula: string; columnName: string; items: TotalItem[]; strict?: boolean };
 export type TotalItem = { dataElement: DataElement; categoryOptionCombo: CategoryOptionCombo };
 
 function getDataElementLabel(

--- a/src/webapp/reports/autogenerated-forms/GridWithPeriodsViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/GridWithPeriodsViewModel.ts
@@ -247,6 +247,7 @@ export class GridWithPeriodsViewModel {
                         columnName: column.label,
                         formula: getFormulaByColumnName(section, "") || sectionTotal.formula || "",
                         items: columnWithDataElements,
+                        strict: sectionTotal.strict,
                     };
                 });
 

--- a/src/webapp/reports/autogenerated-forms/datatables/DataTableCellFormula.tsx
+++ b/src/webapp/reports/autogenerated-forms/datatables/DataTableCellFormula.tsx
@@ -21,7 +21,7 @@ export type DataTableCellFormulaProps = {
 export const DataTableCellFormula: React.FC<DataTableCellFormulaProps> = props => {
     const { dataFormInfo, formula, period, styles, total } = props;
     const totalCalculated = _(total.items)
-        .map(itemTotal => getItemTotalDataValue(dataFormInfo, itemTotal, period))
+        .map(itemTotal => getItemTotalDataValue(dataFormInfo, itemTotal, period, total.strict))
         .compact()
         .value();
 
@@ -38,8 +38,9 @@ export const DataTableCellFormula: React.FC<DataTableCellFormulaProps> = props =
 export function getItemTotalDataValue(
     dataFormInfo: DataFormInfo,
     itemTotal: TotalItem,
-    period?: string
+    period?: string,
+    strict?: boolean
 ): Maybe<Record<string, Maybe<number>>> {
-    const numericValue = getValueFromDataElement(dataFormInfo, itemTotal, period);
+    const numericValue = getValueFromDataElement(dataFormInfo, itemTotal, period, strict);
     return numericValue && window.isNaN(numericValue) ? undefined : { [itemTotal.dataElement.code]: numericValue };
 }

--- a/src/webapp/reports/autogenerated-forms/datatables/DataTableCellRowTotal.tsx
+++ b/src/webapp/reports/autogenerated-forms/datatables/DataTableCellRowTotal.tsx
@@ -27,7 +27,7 @@ export const DataTableCellRowTotal: React.FC<DataTableCellRowTotalProps> = props
             ? dataElement.categoryOptionCombos.filter(coc => onlyCocIds?.includes(coc.id))
             : dataElement.categoryOptionCombos;
 
-    const totalValue = _(combinationsToCalculate)
+    const totalValues = _(combinationsToCalculate)
         .map(coc => {
             const deValue = dataFormInfo.data.values.get(
                 {
@@ -40,10 +40,12 @@ export const DataTableCellRowTotal: React.FC<DataTableCellRowTotalProps> = props
                     period: period || dataFormInfo.period,
                 }
             ) as DataValueNumberSingle;
-            return Number(deValue.value);
+            return deValue.value === undefined ? undefined : Number(deValue.value);
         })
-        .compact()
-        .sum();
+        .compact();
+
+    // if no values are set, return empty string instead of 0
+    const totalValue = totalValues.some() ? totalValues.sum() : "";
 
     return (
         <CustomDataTableCell colSpan={colSpan} backgroundColor={styles.rows.backgroundColor} key="total-row">

--- a/src/webapp/reports/autogenerated-forms/datatables/DataTableCellSummary.tsx
+++ b/src/webapp/reports/autogenerated-forms/datatables/DataTableCellSummary.tsx
@@ -21,7 +21,9 @@ export type DataTableCellSummaryProps = {
 export const DataTableCellSummary: React.FC<DataTableCellSummaryProps> = props => {
     const { dataFormInfo, styles, dataElements, period } = props;
     const totals = _(dataElements).map(cellTotal => {
-        const values = cellTotal.items.map(itemTotal => getItemTotalDataValue(dataFormInfo, itemTotal, period));
+        const values = cellTotal.items.map(itemTotal =>
+            getItemTotalDataValue(dataFormInfo, itemTotal, period, cellTotal.strict)
+        );
         const compiled = _.template(cellTotal.formula);
         return compiled(_.merge({}, ...values));
     });
@@ -40,7 +42,8 @@ export const DataTableCellSummary: React.FC<DataTableCellSummaryProps> = props =
 export function getValueFromDataElement(
     dataFormInfo: DataFormInfo,
     itemTotal: TotalItem,
-    period?: Period
+    period?: Period,
+    strict?: boolean
 ): Maybe<number> {
     const dataElementToRead = resolveDataElement(dataFormInfo, itemTotal.dataElement);
     const dataValue = dataFormInfo.data.values.getOrEmpty(dataElementToRead, {
@@ -48,7 +51,7 @@ export function getValueFromDataElement(
         orgUnitId: dataFormInfo.orgUnitId,
         period: period || dataFormInfo.period,
     }) as DataValueNumberSingle;
-    if (dataValue.value === "") {
+    if (strict && dataValue.value === "") {
         return undefined;
     }
     const numericValue = Number(dataValue.value);

--- a/src/webapp/reports/autogenerated-forms/datatables/DataTableCellSummary.tsx
+++ b/src/webapp/reports/autogenerated-forms/datatables/DataTableCellSummary.tsx
@@ -20,13 +20,16 @@ export type DataTableCellSummaryProps = {
 
 export const DataTableCellSummary: React.FC<DataTableCellSummaryProps> = props => {
     const { dataFormInfo, styles, dataElements, period } = props;
-    const totalCalculated = _(dataElements)
-        .map(cellTotal => {
-            const values = cellTotal.items.map(itemTotal => getItemTotalDataValue(dataFormInfo, itemTotal, period));
-            const compiled = _.template(cellTotal.formula);
-            return compiled(_.merge({}, ...values));
-        })
-        .sumBy(Number);
+    const totals = _(dataElements).map(cellTotal => {
+        const values = cellTotal.items.map(itemTotal => getItemTotalDataValue(dataFormInfo, itemTotal, period));
+        const compiled = _.template(cellTotal.formula);
+        return compiled(_.merge({}, ...values));
+    });
+
+    // formula evaluation in totals can return NaN if values are undefined
+    const totalCalculated = totals.every(value => Number.isNaN(Number(value)) || value === "")
+        ? ""
+        : totals.sumBy(value => (Number.isNaN(Number(value)) ? 0 : Number(value)));
 
     return (
         <CustomDataTableCell backgroundColor={styles.totals.backgroundColor} key="column-totals">
@@ -45,7 +48,9 @@ export function getValueFromDataElement(
         orgUnitId: dataFormInfo.orgUnitId,
         period: period || dataFormInfo.period,
     }) as DataValueNumberSingle;
-
+    if (dataValue.value === "") {
+        return undefined;
+    }
     const numericValue = Number(dataValue.value);
     return window.isNaN(numericValue) ? undefined : numericValue;
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869brj0y2 #869brj0y2

### :memo: Implementation

- DEPENDS ON #139 (based on that branch since I required previous features)
- Add the flag `strict` to the totals dataStore config. 
  - when `strict` is `true`, then dataValues will not be automatically converted to 0 when empty.
  - this was to not break backwards compatibility in case there are preexisting formulas that rely on the automatic conversion from `''` to `0`.
  - We could analyze if this flag is required and remove it and change the default behavior if needed.
- In `getValueFromDataElement`, instead of always converting empty values to 0, return `undefined` if the value is empty and `strict` is true.
- In `DataTableCellSummary` handle the possibility of formula evaluations returning `NaN`. Show an empty value if all previous values are empty or NaN.
- The change to `getValueFromDataElement` will impact `getItemTotalDataValue` `DataTableCellFormula`. As formula values will be `undefined` instead of `0`, calculations might start returning `NaN`, but that is handled in `DataTableCellFormula` `CustomInput` value parameter.
- Also modified `DataTableCellRowTotal` to be consistent with this behavior. If the values to the left are not set, show empty instead of 0 (this is a change despite the `strict` flag setting)

I'm was not totally convinced about this PR, but looks like an acceptable workaround without too many changes. 
The flag makes it more verbose but was an attempt to not break backwards compat.

### :art: Screenshots

### :fire: Notes to the tester
