### PR TITLE
[feature]: add header option to firstColumnConfig

### DIFF
--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -144,7 +144,8 @@ interface GridSectionConfig extends BaseSectionConfig {
         }
     >;
     firstColumnConfig?: {
-        width: number;
+        width: Maybe<number>;
+        header: Maybe<string>;
     };
     periods: Period[];
 }
@@ -460,7 +461,9 @@ const DataStoreConfigCodec = Codec.interface({
             sectionConfig({
                 dataElementsToExclude: optional(array(dataElementsToExcludeCodec)),
                 categoryOptionFilter: optional(categoryOptionFilterConfigCodec),
-                firstColumnConfig: optional(Codec.interface({ width: number })),
+                firstColumnConfig: optional(
+                    Codec.interface({ width: optional(number), header: optional(oneOf([string, selector])) })
+                ),
                 singleCategoryInColumns: optional(boolean),
                 rowsConfig: optional(
                     record(
@@ -974,6 +977,15 @@ export class Dhis2DataStoreDataForm {
             .compact()
             .value();
 
+        const firstColumnHeaderCodes = _(storeConfig.dataSets)
+            .values()
+            .flatMap(dataSet => _.values(dataSet.sections))
+            .map(section => section.firstColumnConfig?.header)
+            .compact()
+            .map(header => (typeof header !== "string" ? header.code : undefined))
+            .compact()
+            .value();
+
         const virtualCodes = virtualColumnsCodes.concat(virtualRowsCodes).concat(rowNamesKeys);
 
         const dataSetRulesCodes = _(storeConfig.dataSets)
@@ -994,7 +1006,7 @@ export class Dhis2DataStoreDataForm {
         ])
             .map(v => (typeof v !== "string" && !Array.isArray(v) ? v?.code : undefined))
             .compact()
-            .concat([...descriptionCodes, ...totalsCodes, ...dataSetRulesCodes])
+            .concat([...descriptionCodes, ...totalsCodes, ...dataSetRulesCodes, ...firstColumnHeaderCodes])
             .uniq()
             .value();
 
@@ -1127,6 +1139,15 @@ export class Dhis2DataStoreDataForm {
                     case "table":
                     case "grid":
                     case "grid-with-totals": {
+                        const firstColumnConfig = sectionConfig.firstColumnConfig
+                            ? {
+                                  ...sectionConfig.firstColumnConfig,
+                                  header: this.getTextFromConstants(
+                                      sectionConfig.firstColumnConfig.header,
+                                      constantsByCode
+                                  ),
+                              }
+                            : undefined;
                         const config = {
                             ...baseConfig,
                             viewType,
@@ -1134,7 +1155,7 @@ export class Dhis2DataStoreDataForm {
                             columnsOrder: sectionConfig.columnsOrder,
                             enableGroups: sectionConfig.enableGroups || false,
                             columnsConfig: sectionConfig.columnsConfig,
-                            firstColumnConfig: sectionConfig.firstColumnConfig,
+                            firstColumnConfig: firstColumnConfig,
                             periods: getSectionPeriods(viewType, period, sectionConfig.periods, periodType),
                         };
                         return [section.id, config] as [typeof section.id, typeof config];

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -138,7 +138,8 @@ export interface SectionGrid extends SectionBase {
     columnsOrder: Maybe<ColumnOrder>;
     columnsConfig?: Record<string, { rules?: RulesFormula }>;
     firstColumnConfig: Maybe<{
-        width: number;
+        width: Maybe<number>;
+        header: Maybe<string>;
     }>;
     periods: Period[];
 }

--- a/src/webapp/reports/autogenerated-forms/GridForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridForm.tsx
@@ -102,7 +102,11 @@ const GridForm: React.FC<GridFormProps> = props => {
                                         width={`${firstColumnWidth}px`}
                                         position={fixColumns ? "sticky" : undefined}
                                         left={fixColumns ? "162px" : undefined}
-                                    ></CustomDataTableColumnHeader>
+                                    >
+                                        <span className={classes.header}>
+                                            {section.firstColumnConfig?.header || ""}
+                                        </span>
+                                    </CustomDataTableColumnHeader>
                                 )
                             )}
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bpnh49 #869bpnh49

### :memo: Implementation

- There was an existing property `firstColumnConfig` being used for the grid type. Added a new `header` property there
- `header` can be either string or constant ref
- Made `firstColumnConfig.width` optional in case we want only to customize the header.

### :art: Screenshots

### :fire: Notes to the tester
