### PR TITLE
feat: remove duplicated section.name in TableForm

### DIFF
--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -11,7 +11,6 @@ import {
     DataTableRow,
     TableBody, // @ts-ignore
 } from "@dhis2/ui";
-import { makeStyles } from "@material-ui/core";
 import DataTableSection from "./DataTableSection";
 import { CustomDataTableCell, CustomDataTableColumnHeader } from "./datatables/CustomDataTables";
 import { DataTableCellRowName } from "./datatables/DataTableCellRowName";
@@ -32,7 +31,6 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
         () => GridViewModel.get(props.section, dataFormInfo, "table"),
         [props.section, dataFormInfo]
     );
-    const classes = useStyles();
 
     const Indicators = section.indicators.map(indicator => {
         return (
@@ -50,17 +48,11 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
             <DataTable>
                 <TableHead>
                     <DataTableRow>
-                        {!_.isEmpty(section.columns) && (
-                            <CustomDataTableColumnHeader
-                                backgroundColor={props.section.styles.columns.backgroundColor}
-                                colSpan={section.dataEntryPeriod ? "1" : "2"}
-                            >
-                                <span className={classes.header}>{section.name}</span>
-                            </CustomDataTableColumnHeader>
-                        )}
-
                         {section.dataEntryPeriod && (
                             <>
+                                <CustomDataTableColumnHeader
+                                    backgroundColor={props.section.styles.columns.backgroundColor}
+                                ></CustomDataTableColumnHeader>
                                 <CustomDataTableColumnHeader
                                     backgroundColor={props.section.styles.columns.backgroundColor}
                                     width="50px"
@@ -158,13 +150,6 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
             </DataTable>
         </DataTableSection>
     );
-});
-
-const useStyles = makeStyles({
-    wrapper: { margin: 10 },
-    header: { fontSize: "1.4em", fontWeight: "bold" as const },
-    center: { display: "table", margin: "0 auto" },
-    tableStyles: { backgroundColor: "aqua !important" },
 });
 
 export default React.memo(TableForm);

--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -14,7 +14,6 @@ import {
 import DataTableSection from "./DataTableSection";
 import { CustomDataTableCell, CustomDataTableColumnHeader } from "./datatables/CustomDataTables";
 import { DataTableCellRowName } from "./datatables/DataTableCellRowName";
-import _ from "lodash";
 import { checkIndicatorDirection } from "../../../domain/common/entities/Indicator";
 import { RowIndicatorItem } from "../../components/IndicatorItem/IndicatorItem";
 import { DataTableCellFormula } from "./datatables/DataTableCellFormula";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bza8vf #869bza8vf

### :memo: Implementation

- `table` viewType was including the `section.name` as the column header. This caused it to be duplicated in relation to the the section header
- With this change the gray table header won't render, except there is a periodOffset. In that case, an empty column header was added for proper display
- Remove unused styles

We need to make sure we want this new behavior for other preexisting dataSets.

### :art: Screenshots

Before: 
<img width="1359" height="194" alt="imagen" src="https://github.com/user-attachments/assets/2eb31547-e055-4cb1-b021-b164ae5397af" />


After:
<img width="1359" height="194" alt="imagen" src="https://github.com/user-attachments/assets/f36c4d6e-6caf-49aa-a6c1-c2c04b2b906b" />


### :fire: Notes to the tester
