### PR TITLE
[fix]: Section toggle visibility for data elements with multiple category option combos

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -793,7 +793,7 @@ function getSectionBaseWithToggle(
                     },
                 };
             } else {
-                console.warn(`Data element for toggle not found in section: ${toggle.code}`);
+                console.warn(`Data element for toggle not found: ${toggle.code}`);
                 return base;
             }
         }

--- a/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
+++ b/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
@@ -338,7 +338,6 @@ const useStyles = makeStyles({
 });
 
 const StyledAppBar = styled(AppBar)`
-    inset-block-start: 48px !important;
     z-index: 100 !important;
 `;
 

--- a/src/webapp/reports/autogenerated-forms/hooks/useSectionVisibility.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useSectionVisibility.ts
@@ -70,12 +70,24 @@ export function useSectionVisibility(section: DataTableSectionObj, dataFormInfo:
 function evaluateSectionOpenState(toggle: Section["toggle"], dataFormInfo: DataFormInfo): boolean {
     switch (toggle.type) {
         case "dataElement": {
-            const dataValue = dataFormInfo.data.values.getOrEmpty(toggle.dataElement, dataFormInfo);
-            return isDataValueEnabled(dataValue);
+            const dataValues = toggle.dataElement.categoryOptionCombos.map(coc => {
+                const updatedDataElement = {
+                    ...toggle.dataElement,
+                    cocId: coc.id,
+                };
+                return dataFormInfo.data.values.getOrEmpty(updatedDataElement, dataFormInfo);
+            });
+            return dataValues.some(dv => isDataValueEnabled(dv));
         }
         case "dataElementExternal": {
-            const dataValue = dataFormInfo.data.values.getOrEmpty(toggle.dataElement, dataFormInfo);
-            return verifyConditionByDataValueType(dataValue, toggle);
+            const dataValues = toggle.dataElement.categoryOptionCombos.map(coc => {
+                const updatedDataElement = {
+                    ...toggle.dataElement,
+                    cocId: coc.id,
+                };
+                return dataFormInfo.data.values.getOrEmpty(updatedDataElement, dataFormInfo);
+            });
+            return dataValues.some(dv => verifyConditionByDataValueType(dv, toggle));
         }
         default:
             return true;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869c0mm1b

### :memo: Implementation
**Problem:**
Section visibility toggles were not working correctly for data elements that have multiple category option combos (COCs). The previous implementation only checked a single data value, which caused sections to remain hidden even when data existed in other COCs.

**Solution:**
Updated the `useSectionVisibility` hook to iterate through all category option combos of a toggle data element and check if any of them have a value that satisfies the visibility condition.

### :art: Screenshots

https://github.com/user-attachments/assets/8c7b7be5-7429-4bf1-b448-075c07ad9666


### :fire: Notes to the tester

#869c0mm1b