### PR TITLE
[fix]: add colSpan to RowIndicatorItem when there is a period offset

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -61,7 +61,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
         <RowIndicatorItem
             key={`parent_${indicator.id}`}
             indicator={indicator}
-            colSpan="2"
+            colSpan={grid.periods.length > 0 ? "3" : "2"}
             dataFormInfo={dataFormInfo}
             periods={[dataFormInfo.period]}
         />

--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -36,7 +36,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
             <RowIndicatorItem
                 key={`parent_${indicator.id}`}
                 indicator={indicator}
-                colSpan="0"
+                colSpan={section.dataEntryPeriod ? "2" : "1"}
                 dataFormInfo={dataFormInfo}
                 periods={[section.dataEntryPeriod?.id || dataFormInfo.period]}
             />


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bhdf72 #869bhdf72

### :memo: Implementation

- Reintroduces the changes implemented in #133 that were lost during #135 implementation
- This fixes the alignment of the indicator input when there is a periodOffset in the table and grid-with-cat-option-combos viewTypes

### :art: Screenshots

<img width="1164" height="141" alt="image" src="https://github.com/user-attachments/assets/6c24d4ac-e303-4ded-b372-8e6e149e86f7" />


### :fire: Notes to the tester
