### PR TITLE
[feature]: Hide options in an option set

### DIFF
--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -426,21 +426,28 @@ const indicatorsDirectionalConfigCodec = Codec.interface({
     headers: array(oneOf([string, selector])),
 });
 
+const optionSetCodec = Codec.interface({
+    code: string,
+    options: optionalRecord({
+        hidden: optional(boolean),
+    }),
+});
+
 const DataStoreConfigCodec = Codec.interface({
-    categoryCombinations: sectionConfig({
+    categoryCombinations: optionalRecord({
         viewType: optional(oneOf([exactly("name"), exactly("shortName"), exactly("formName")])),
     }),
-    categoryOptions: sectionConfig({
+    categoryOptions: optionalRecord({
         visible: optional(boolean),
     }),
-    dataElements: sectionConfig({
+    dataElements: optionalRecord({
         disabled: optional(boolean),
         disableComments: optional(boolean),
         mirrorFrom: optional(string),
         rules: optional(dataElementRuleCodec),
         selection: optional(
             Codec.interface({
-                optionSet: optional(selector),
+                optionSet: optional(optionSetCodec),
                 isMultiple: optional(boolean),
                 widget: optional(
                     oneOf([exactly("dropdown"), exactly("radio"), exactly("sourceType"), exactly("checkbox")])
@@ -456,7 +463,7 @@ const DataStoreConfigCodec = Codec.interface({
         texts: optional(textsCodec),
     }),
 
-    dataSets: sectionConfig({
+    dataSets: optionalRecord({
         disableComments: optional(boolean),
         removePrefix: optional(string),
         viewType: optional(viewType),
@@ -465,7 +472,7 @@ const DataStoreConfigCodec = Codec.interface({
         showIndex: optional(boolean),
         rules: optional(array(dataSetRuleCodec)),
         sections: optional(
-            sectionConfig({
+            optionalRecord({
                 dataElementsToExclude: optional(array(dataElementsToExcludeCodec)),
                 categoryOptionFilter: optional(categoryOptionFilterConfigCodec),
                 firstColumnConfig: optional(
@@ -523,7 +530,7 @@ const DataStoreConfigCodec = Codec.interface({
                 totals: optional(oneOf([totalsType, record(string, totalsType)])),
                 toggleMultiple: optional(toggleMultipleCodec),
                 indicators: optional(
-                    sectionConfig({
+                    optionalRecord({
                         position: optional(
                             Codec.interface({
                                 direction: oneOf([exactly("after"), exactly("before")]),
@@ -602,9 +609,11 @@ export interface DataElementConfig {
 
 export type IndicatorConfig = { position: Maybe<{ dataElement: string; direction: "after" | "before" }> };
 
+type OptionSetOption = Option<string>;
+
 interface OptionSet extends NamedRef {
     code: string;
-    options: Option<string>[];
+    options: OptionSetOption[];
 }
 
 type Selector = GetType<typeof selector>;
@@ -880,13 +889,13 @@ export class Dhis2DataStoreDataForm {
     }
 
     private static async getOptionSets(api: D2Api, storeConfig: DataFormStoreConfig["custom"]): Promise<OptionSet[]> {
-        const codes = _(storeConfig.dataElements)
+        const optionSets = _(storeConfig.dataElements)
             .values()
-            .map(obj => obj.selection?.optionSet)
+            .map(de => de.selection?.optionSet)
             .compact()
-            .map(sel => sel.code)
             .value();
 
+        const codes = optionSets.map(sel => sel.code);
         if (_.isEmpty(codes)) return [];
 
         const res = await api.metadata
@@ -906,10 +915,19 @@ export class Dhis2DataStoreDataForm {
         return res.optionSets.map(
             (optionSet): OptionSet => ({
                 ...optionSet,
-                options: optionSet.options.map(option => ({
-                    name: option.displayName,
-                    value: option.code,
-                })),
+                options: _(optionSet.options)
+                    .map(option => {
+                        const matchedOptionSet = optionSets.find(os => os.code === optionSet.code);
+                        const hidden = matchedOptionSet?.options?.[option.code]?.hidden ?? false;
+                        if (hidden) return undefined;
+
+                        return {
+                            name: option.displayName,
+                            value: option.code,
+                        };
+                    })
+                    .compact()
+                    .value(),
             })
         );
     }
@@ -1478,7 +1496,7 @@ interface Constant {
     displayDescription: string;
 }
 
-function sectionConfig<T extends Record<string, Codec<any>>>(properties: T) {
+function optionalRecord<T extends Record<string, Codec<any>>>(properties: T) {
     return optional(record(string, Codec.interface(properties)));
 }
 

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -912,12 +912,13 @@ export class Dhis2DataStoreDataForm {
             })
             .getData();
 
-        return res.optionSets.map(
-            (optionSet): OptionSet => ({
+        return res.optionSets.map((optionSet): OptionSet => {
+            const matchedOptionSet = optionSets.find(os => os.code === optionSet.code);
+
+            return {
                 ...optionSet,
                 options: _(optionSet.options)
                     .map(option => {
-                        const matchedOptionSet = optionSets.find(os => os.code === optionSet.code);
                         const hidden = matchedOptionSet?.options?.[option.code]?.hidden ?? false;
                         if (hidden) return undefined;
 
@@ -928,8 +929,8 @@ export class Dhis2DataStoreDataForm {
                     })
                     .compact()
                     .value(),
-            })
-        );
+            };
+        });
     }
 
     private static async getConstants(api: D2Api, storeConfig: DataFormStoreConfig["custom"]): Promise<Constant[]> {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869c6jttu

### :memo: Implementation
- [x] Filter out options in an optionSet that are hidden using the dataElements.selection.optionSet config
```
{
  "DE_CODE": {
    "selection": {
      "optionSet": {
        "code": "OPTION_SET_CODE",
        "options": {
          "OPTION_CODE": {
            "hidden": true
          }
        }
      }
    }
  }
}
```
### :art: Screenshots
Hiding the "No" option here:
<img width="1430" height="687" alt="Screenshot 2026-02-20 at 09 27 05" src="https://github.com/user-attachments/assets/226dd75c-1bdb-4501-8b8b-45bfbda5eafc" />

### :fire: Notes to the tester

#869c6jttu