### PR TITLE
[fix]: catOptionFormName when there are no columns

### DIFF
--- a/src/webapp/reports/autogenerated-forms/DisaggregatedCOCsGridViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/DisaggregatedCOCsGridViewModel.ts
@@ -138,7 +138,7 @@ export class DisaggregatedCOCsGridViewModel {
                     });
 
                 const catOptionFormName = getCocFormNameFromCombos(
-                    items.flatMap(i => i.rowItems.flatMap(ri => ri.categoryOptionCombos)),
+                    items.flatMap(i => i.dataElement.categoryOptionCombos),
                     rowCatOptionCode
                 );
                 return {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869cct4g7 #869cct4g7

### :memo: Implementation

- We had a case in viewType `grid-disaggregated-cocs` where all columns where hidden due to `columnsConfig` rules (only totals displayed). In this case the rowName was falling back to the `rowCatOptionCode`.
- When `columns` is empty, `rowItems` is empty, causing `catOptionFormName` to fall back to `rowCatOptionCode`. The fix is to use `dataElement.categoryOptionCombos` instead, which still represents the same row category option even when no visible cells remain.

### :art: Screenshots

Before:
<img width="455" height="374" alt="imagen" src="https://github.com/user-attachments/assets/d47eafa5-1a09-4305-ad6f-67fdeb922062" />

After:
<img width="433" height="380" alt="imagen" src="https://github.com/user-attachments/assets/d08a5e33-aac2-4c5b-a25b-6152717a6c56" />


### :fire: Notes to the tester
