### PR TITLE
[fix]: apply section disabled config to table viewType

### DIFF
--- a/src/webapp/reports/autogenerated-forms/TableForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/TableForm.tsx
@@ -105,7 +105,7 @@ const TableForm: React.FC<TableFormProps> = React.memo(props => {
                                             noComment={dataElement.disabledComments}
                                             period={section.dataEntryPeriod?.id}
                                             lockException={section.dataEntryPeriod !== undefined}
-                                            manualyDisabled={dataElement.disabled}
+                                            manualyDisabled={dataElement.disabled || props.section.disabled}
                                         />
                                     </CustomDataTableCell>
                                 </DataTableRow>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related https://app.clickup.com/t/869cjm1n5 #869cjm1n5

### :memo: Implementation

- Section disable config was being applied only for `GridWithPeriods`. This adds section disabled support for tables, needed for the GAM sections in TUB dataset. 
- Other viewTypes are still missing `disabled` support. 
  - Created this PR to keep scope small and be in the safe side.
  - I have some local changes to support other viewTypes I can create in a separate PR

### :art: Screenshots

### :fire: Notes to the tester
