### PR TITLE
[feature]: column name override for DisaggregatedCOCsGrid

### DIFF
--- a/src/data/common/Dhis2DataFormRepository.ts
+++ b/src/data/common/Dhis2DataFormRepository.ts
@@ -29,6 +29,7 @@ import { buildToggleMultiple } from "../../domain/common/entities/ToggleMultiple
 import { DataFormRepository } from "../../domain/common/repositories/DataFormRepository";
 import { D2Api, MetadataPick } from "../../types/d2-api";
 import { Maybe } from "../../utils/ts-utils";
+import { RulesFormula } from "./RulesFormula";
 import { Dhis2DataElement } from "./Dhis2DataElement";
 import { DEFAULT_INDICATORS_POSITION, Dhis2DataStoreDataForm } from "./Dhis2DataStoreDataForm";
 import {
@@ -287,6 +288,7 @@ export class Dhis2DataFormRepository implements DataFormRepository {
                             viewType: config.viewType,
                             rowsConfig: buildRowsConfigWithTexts(config.rowsConfig, configDataForm.constants),
                             ...base2,
+                            columnsConfig: buildColumnsConfigWithTexts(config.columnsConfig, configDataForm.constants),
                         };
                     default:
                         return { viewType: config.viewType, ...base2 };
@@ -834,6 +836,28 @@ function buildRowsConfigWithTexts(
                     cellsVisible: rowConfig.cellsVisible ?? true,
                     rowName: constant?.displayDescription,
                     hide: rowConfig.hide,
+                },
+            ];
+        })
+        .fromPairs()
+        .value();
+}
+
+function buildColumnsConfigWithTexts(
+    columnsConfig: Maybe<Record<string, { rules?: RulesFormula; columnNameConstant?: string }>>,
+    constants: Array<{ code: string; displayDescription?: string }>
+): SectionBase["columnsConfig"] {
+    if (!columnsConfig) return undefined;
+
+    return _(columnsConfig)
+        .map((colConfig, key): [string, { rules?: RulesFormula; columnName?: string }] => {
+            const constant = constants.find(c => c.code === colConfig.columnNameConstant);
+
+            return [
+                key,
+                {
+                    rules: colConfig.rules,
+                    columnName: constant?.displayDescription,
                 },
             ];
         })

--- a/src/data/common/Dhis2DataStoreDataForm.ts
+++ b/src/data/common/Dhis2DataStoreDataForm.ts
@@ -324,7 +324,12 @@ export const DataStoreConfigCodec = Codec.interface({
                     )
                 ),
                 categoriesColumns: optional(array(Codec.interface({ dataElementCode: string, categoryCode: string }))),
-                columnsConfig: optional(record(string, Codec.interface({ rules: optional(rulesFormulaCodec) }))),
+                columnsConfig: optional(
+                    record(
+                        string,
+                        Codec.interface({ rules: optional(rulesFormulaCodec), columnNameConstant: optional(string) })
+                    )
+                ),
                 disabled: optional(boolean),
                 columnsOrder: optional(record(string, number)),
                 fixedHeaders: optional(boolean),
@@ -823,7 +828,15 @@ export class Dhis2DataStoreDataForm {
             .compact()
             .value();
 
-        const virtualCodes = virtualColumnsCodes.concat(virtualRowsCodes).concat(rowNamesKeys);
+        const columnNameKeys = _(storeConfig.dataSets)
+            .values()
+            .flatMap(dataSet => _.values(dataSet.sections))
+            .flatMap(section => _.values(section.columnsConfig))
+            .map(colConfig => colConfig.columnNameConstant)
+            .compact()
+            .value();
+
+        const virtualCodes = virtualColumnsCodes.concat(virtualRowsCodes).concat(rowNamesKeys).concat(columnNameKeys);
 
         const dataSetRulesCodes = _(storeConfig.dataSets)
             .values()

--- a/src/domain/common/entities/AutogenConfig.ts
+++ b/src/domain/common/entities/AutogenConfig.ts
@@ -179,7 +179,7 @@ type GridIndicatorsCalculated = BaseSectionConfig & {
     virtualColumns: (VirtualColumnDataElement | VirtualColumnCalculated)[];
 };
 
-type GridColumnsConfig = Record<string, { rules?: FromRulesFormulaCodec }>;
+type GridColumnsConfig = Record<string, { rules?: FromRulesFormulaCodec; columnNameConstant?: string }>;
 
 type RowsConfig = Record<string, { cellsVisible?: boolean; rowNameConstant?: string; hide?: boolean }>;
 

--- a/src/domain/common/entities/DataForm.ts
+++ b/src/domain/common/entities/DataForm.ts
@@ -131,7 +131,7 @@ export interface SectionBase {
     enableTopScroll: boolean;
     fixedRowNames: boolean;
     hidden?: boolean;
-    columnsConfig?: Record<string, { rules?: RulesFormula }>;
+    columnsConfig?: Record<string, { rules?: RulesFormula; columnName?: string }>;
     rules: SectionRule[];
 }
 
@@ -154,7 +154,7 @@ export interface SectionGrid extends SectionBase {
     enableGroups: boolean;
     calculateTotals: CalculateTotalType;
     columnsOrder: Maybe<ColumnOrder>;
-    columnsConfig?: Record<string, { rules?: RulesFormula }>;
+    columnsConfig?: Record<string, { rules?: RulesFormula; columnName?: string }>;
     firstColumnConfig: Maybe<{
         width: Maybe<number>;
         header: Maybe<string>;

--- a/src/webapp/reports/autogenerated-forms/DisaggregatedCOCsGridViewModel.ts
+++ b/src/webapp/reports/autogenerated-forms/DisaggregatedCOCsGridViewModel.ts
@@ -37,12 +37,14 @@ export class DisaggregatedCOCsGridViewModel {
             const columnItems = _(dataElement.categoryOptionCombos)
                 .map((coc): ColumnItem => {
                     const categoryOption = getCocOption(coc);
-                    const columnName = categoryOption.formName;
+                    const columnCode = `${dataElement.code}${COLUMNS_CONFIG_SEPARATOR}${categoryOption.code}`;
+                    const overrideName = section.columnsConfig?.[columnCode]?.columnName;
+                    const columnName = overrideName ?? categoryOption.formName;
 
                     const columnItem: ColumnItem = {
-                        name: _(columnName).capitalize(),
-                        code: `${dataElement.code}${COLUMNS_CONFIG_SEPARATOR}${categoryOption.code}`,
-                        description: getDescription(section.columnsDescriptions, dataFormInfo, columnName),
+                        name: overrideName ? columnName : _(columnName).capitalize(),
+                        code: columnCode,
+                        description: getDescription(section.columnsDescriptions, dataFormInfo, categoryOption.formName),
                         isVisible: true,
                     };
 
@@ -93,11 +95,12 @@ export class DisaggregatedCOCsGridViewModel {
                         const rowItems = _(dataElement.categoryOptionCombos)
                             .filter(item => getRowCategoryOptionCodeFromCoc(item) === rowCatOptionCode)
                             .map(coc => {
+                                const cocOption = getCocOption(coc);
+                                const cocColumnCode = `${dataElement.code}${COLUMNS_CONFIG_SEPARATOR}${cocOption.code}`;
                                 const columnName =
                                     columns
                                         .find(column => column.dataElement.id === dataElement.id)
-                                        ?.columnItems.find(columnItem => columnItem.name === getColumnNameFromCoc(coc))
-                                        ?.name || "";
+                                        ?.columnItems.find(columnItem => columnItem.code === cocColumnCode)?.name || "";
 
                                 if (!columnName) return undefined;
 
@@ -199,7 +202,7 @@ export class DisaggregatedCOCsGridViewModel {
         const { section, column, dataFormInfo } = options;
 
         const config = section.columnsConfig ? section.columnsConfig[column.code] : undefined;
-        if (!config) return { ...column, isVisible: true };
+        if (!config || !config.rules?.visible) return { ...column, isVisible: true };
 
         const dataElementCodes = _(config.rules?.visible?.dataElements)
             .map(dataElement => dataElement.code)
@@ -300,11 +303,6 @@ const sortItems = <T extends { name: string }>(items: T[], unknownPatterns: stri
 
     return sortedItems.map(x => x.item);
 };
-
-function getColumnNameFromCoc(categoryOptionCombo: CategoryOptionCombo): Maybe<string> {
-    const cocName = categoryOptionCombo.name.split(separator)[0];
-    return getCocFormName(categoryOptionCombo, cocName);
-}
 
 function getRowCategoryOptionCodeFromCoc(categoryOptionCombo: CategoryOptionCombo): Maybe<string> {
     return categoryOptionCombo.name.split(separator)[1];


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related https://app.clickup.com/t/869cjm1n5 #869cjm1n5

### :memo: Implementation

We needed a way to override a column header for `DisaggregatedCOCsGrid`.
For rows, `rowsConfig.rowNameConstant` already existed. Here we are trying to replicate something similar but for columns. 
`columnsConfig` already existed, but did not allow for this customization.

- Add `columnNameConstant` to `columnsConfig`
- Handle `columnsConfig` entry without rules
  - After adding the config only with the `rowNameConstant` prop, the column was being incorrectly hidden
- Cell-to-column matching from name-based to code-based lookup
  - After the name override, the cells stopped rendering because it was using the name to build the grid. Changed that to use codes

Example config: 
```json
"TUB_BEDAQUILINE_LINEZOLID_SUSC_TESTING_AMONG": {
  "columnsConfig": {
    "TUB_rr_fqr_dst||TUB_UNKNOWN": {
      "columnNameConstant": "TUB_UNKNOWN_TO_BEDAQUILINE_COL_LBL"
    }
  }
}
```

### :art: Screenshots

### :fire: Notes to the tester
