### PR TITLE
normalize category options

### DIFF
--- a/src/data/common/Dhis2DataElement.ts
+++ b/src/data/common/Dhis2DataElement.ts
@@ -82,6 +82,29 @@ type D2DataElementNewType = Omit<D2DataElement, "valueType"> & {
     valueType: D2DataElementTypes;
 };
 
+function normalizeCategoryCombo(categoryCombo: D2DataElement["categoryCombo"]): D2DataElement["categoryCombo"] {
+    const trimCategoryOption = (
+        co: D2DataElement["categoryCombo"]["categories"][number]["categoryOptions"][number]
+    ) => ({
+        ...co,
+        code: co.code.trim(),
+        name: co.name.trim(),
+    });
+
+    return {
+        ...categoryCombo,
+        categories: categoryCombo.categories.map(category => ({
+            ...category,
+            categoryOptions: category.categoryOptions.map(trimCategoryOption),
+        })),
+        categoryOptionCombos: categoryCombo.categoryOptionCombos.map(coc => ({
+            ...coc,
+            name: coc.name.trim(),
+            categoryOptions: coc.categoryOptions.map(trimCategoryOption),
+        })),
+    };
+}
+
 export function makeCocOrderArray(namesArray: string[][]): string[] {
     return namesArray.reduce((prev, current) => {
         return prev
@@ -198,6 +221,7 @@ function getVisibleCategoryOptionCombos(
 
 function getDataElement(dataElement: D2DataElementNewType, config: Dhis2DataStoreDataForm): DataElement | null {
     const { valueType } = dataElement;
+    const categoryCombo = normalizeCategoryCombo(dataElement.categoryCombo);
     const deConfig = config.dataElementsConfig[dataElement.code];
     const optionSetFromDataElement = dataElement.optionSet
         ? {
@@ -211,10 +235,10 @@ function getDataElement(dataElement: D2DataElementNewType, config: Dhis2DataStor
     const optionSetFromCustomConfig = deConfig?.selection?.optionSet;
     const optionSet = optionSetFromCustomConfig || optionSetFromDataElement;
     const categoryCombination = {
-        id: dataElement.categoryCombo?.id,
-        name: dataElement.categoryCombo?.name,
-        categories: dataElement.categoryCombo?.categories.map(cat => {
-            const keyName = config.categoryCombinationsConfig[dataElement.categoryCombo.code]?.viewType || "formName";
+        id: categoryCombo?.id,
+        name: categoryCombo?.name,
+        categories: categoryCombo?.categories.map(cat => {
+            const keyName = config.categoryCombinationsConfig[categoryCombo.code]?.viewType || "formName";
             return {
                 ...cat,
                 categoryOptions: cat.categoryOptions.map(co => {
@@ -235,9 +259,9 @@ function getDataElement(dataElement: D2DataElementNewType, config: Dhis2DataStor
                 }),
             };
         }),
-        categoryOptionCombos: getCocOrdered(dataElement.categoryCombo, config),
+        categoryOptionCombos: getCocOrdered(categoryCombo, config),
     };
-    const categoryOptionCombos = getVisibleCategoryOptionCombos(dataElement.categoryCombo.categoryOptionCombos, config);
+    const categoryOptionCombos = getVisibleCategoryOptionCombos(categoryCombo.categoryOptionCombos, config);
 
     const base = {
         id: dataElement.id,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869c4fuc1 https://app.clickup.com/t/869c4fuc1

### :memo: Implementation
**Issue**
- certain fields in GNARF (cLEI tab) are not rendered because of a COC - CO mismatch. (i.e COC name is ` NTD -Relapse cases, NTD -Negative Slides` but CO name was updated to `NTD - LEV-Relapse cases`, note the prefix `-LEV`)
- Since COCs are ordered using CO names, the mismatched caused COC list to be empty giving an empty table

<img width="1295" height="255" alt="image" src="https://github.com/user-attachments/assets/74ec3d1b-7171-43dd-9097-4327f2bd6f06" />

After renaming CO to match COC, caused another table the same issue. This time, it's because COC had -LEV and removing it from CO caused the same kind of mismatch
<img width="1646" height="791" alt="image" src="https://github.com/user-attachments/assets/88986928-91a8-43d4-9fe8-44fac104f76a" />

After running maintenance task to update COC, the age details broke
<img width="1347" height="438" alt="image" src="https://github.com/user-attachments/assets/4c5ca27a-7159-4dae-b1fd-da5cf81170c7" />

It was caused the a similar issue but this time because of trailing `<space>`

**Fix**
normalize CO code and name using trim

### :art: Screenshots

### :fire: Notes to the tester
