### PR TITLE
[fix]: Apply rules to sections with period offset

### DIFF
--- a/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
@@ -313,7 +313,13 @@ function useDataFormInfo() {
                 checkValidationRules(dataValue);
             }
         },
-        [compositionRoot, dataValues, dataForm?.compulsoryDataValues, dataForm?.disableAutoValidation, checkValidationRules]
+        [
+            compositionRoot,
+            dataValues,
+            dataForm?.compulsoryDataValues,
+            dataForm?.disableAutoValidation,
+            checkValidationRules,
+        ]
     );
 
     const deleteDataValues = useCallback<DataFormInfo["data"]["delete"]>(

--- a/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
@@ -82,7 +82,7 @@ function getValueAndVerifyCondition(
         return rules.some(rule => {
             const dataValue = dataFormInfo.data.values.getOrEmpty(rule.relatedDataElement, {
                 orgUnitId: rule.relatedDataElement.orgUnit || dataFormInfo.orgUnitId,
-                period: period || dataFormInfo.period,
+                period: dataFormInfo.period,
                 categoryOptionComboId: dataFormInfo.categoryOptionComboId,
             });
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869cmxcc8

### :memo: Implementation
Fixes rule evaluation for sections that use a period offset. Previously, the getValueAndVerifyCondition function used the period parameter (which could be an offset-adjusted period from a section) when looking up data values for rule conditions. This caused rules to evaluate against the wrong period's data, leading to incorrect rule application.

### :art: Screenshots

### :fire: Notes to the tester

#869cmxcc8