### PR TITLE
fix(tabs): hide scroll arrow when at scroll boundary

### DIFF
--- a/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
+++ b/src/webapp/reports/autogenerated-forms/SectionsTabs.tsx
@@ -463,7 +463,11 @@ const StyledIconButton = styled(IconButton).withConfig({
 })<Omit<ScrollButtonProps, "handleScroll">>`
     opacity: ${props =>
         (!props.showLeftFade && props.direction === "left") || (!props.showRightFade && props.direction === "right")
-            ? 0.5
+            ? 0
+            : undefined};
+    pointer-events: ${props =>
+        (!props.showLeftFade && props.direction === "left") || (!props.showRightFade && props.direction === "right")
+            ? "none"
             : undefined};
     inset-inline-start: ${props => (props.direction === "left" ? "-1rem" : undefined)};
     inset-inline-end: ${props => (props.direction === "right" ? "1rem" : undefined)};


### PR DESCRIPTION
## Summary

The custom tab scroll arrow stayed visible (at `opacity: 0.5`) when its direction was already exhausted. Because it's absolutely positioned with `inset-inline-start: -1rem`, on forms whose first tab starts at x=0 it landed on top of the first tab label.

Reproduces cleanly on the EUR TUB annual form at narrow widths (~857px, 4 tabs): the disabled left arrow overlaps "1 - TREATMENT OUTCOMES". Reported by the WHO GTB team on [ClickUp 869cxtvy2](https://app.clickup.com/t/869cxtvy2).

Set `opacity: 0` + `pointer-events: none` when the direction is exhausted, so the arrow disappears entirely until scrolling in that direction is possible — matching the right-arrow's behavior on forms that already fit their viewport.

## Test plan

- [x] EUR annual (4 tabs, 857×900) — left arrow no longer overlaps "1 - TREATMENT OUTCOMES"
- [x] TUB annual (10 tabs, 857×900) — first tab renders cleanly; right arrow still visible (scroll possible)
- [x] After scrolling right on TUB annual — both arrows visible (both directions scrollable)
- [x] EUR annual at 1800×900 — both arrows hidden (no scroll needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)