### PR TITLE
[refactor]: Convert side-effects from useMemo to useEffect in iFramePortal

### DIFF
--- a/src/webapp/components/iframe-escape-portal/IframeEscapePortal.tsx
+++ b/src/webapp/components/iframe-escape-portal/IframeEscapePortal.tsx
@@ -1,8 +1,10 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { StyleSheetManager } from "styled-components";
 import { StylesProvider, jssPreset } from "@material-ui/core/styles";
 import { create, Jss } from "jss";
+import { getTopAccessibleWindow } from "../../utils/topAccessibleWindow";
+import { Maybe } from "../../../utils/ts-utils";
 
 /**
  * Portals `children` into the topmost same-origin document and rewires styled-components
@@ -16,8 +18,8 @@ type IframeEscapePortalProps = {
     hostStyles?: Partial<CSSStyleDeclaration>;
     children: React.ReactNode;
 };
-
 type MuiProviders = { jss: Jss; sheetsManager: Map<unknown, unknown> };
+type PortalTarget = { host: HTMLElement; mui: MuiProviders };
 
 const muiProvidersCache = new WeakMap<Document, MuiProviders>();
 
@@ -26,61 +28,62 @@ export const IframeEscapePortal: React.FC<IframeEscapePortalProps> = ({
     hostStyles = DEFAULT_HOST_STYLES,
     children,
 }) => {
-    const host = useMemo<HTMLElement>(() => {
-        let win: Window = window;
-        try {
-            while (win.parent && win.parent !== win) {
-                const parentDoc = win.parent.document;
-                if (!parentDoc) break;
-                win = win.parent;
-            }
-        } catch {
-            // Cross-origin ancestor — stop at the last accessible window.
-        }
-        const targetDoc = win.document;
+    const [target, setTarget] = useState<Maybe<PortalTarget>>();
+    const hostStylesRef = useRef(hostStyles);
 
-        const existing = targetDoc.getElementById(hostId);
-        if (existing) return existing;
+    useEffect(() => {
+        const targetDoc = getTopAccessibleWindow().document;
+        const existingHost = targetDoc.getElementById(hostId);
+        const host = existingHost ?? createHostElement(targetDoc, hostId, hostStylesRef.current);
+        const mui = getOrCreateMuiProviders(targetDoc);
+        setTarget({ host: host, mui: mui });
 
-        const element = targetDoc.createElement("div");
-        element.id = hostId;
-        Object.assign(element.style, hostStyles);
-        targetDoc.documentElement.appendChild(element);
-
-        return element;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hostId]); // hostStyles is intentionally omitted so a changing style object does not trigger this
-
-    const { jss, sheetsManager } = useMemo<MuiProviders>(() => {
-        const targetDoc = host.ownerDocument;
-        const cached = muiProvidersCache.get(targetDoc);
-        if (cached) return cached;
-
-        const head = targetDoc.head ?? targetDoc.documentElement;
-        const insertionPoint = targetDoc.createElement("style");
-        insertionPoint.setAttribute("data-autogen-forms-jss", "");
-        head.appendChild(insertionPoint);
-
-        const providers: MuiProviders = {
-            jss: create({ ...jssPreset(), insertionPoint }),
-            sheetsManager: new Map(),
+        return () => {
+            if (!existingHost) host.remove();
         };
-        muiProvidersCache.set(targetDoc, providers);
+    }, [hostId]);
 
-        return providers;
-    }, [host]);
+    if (!target) return null;
 
+    const { host, mui } = target;
     const styleSheetTarget = host.ownerDocument.head ?? host.ownerDocument.documentElement;
 
     return ReactDOM.createPortal(
         <StyleSheetManager target={styleSheetTarget}>
-            <StylesProvider jss={jss} sheetsManager={sheetsManager}>
+            <StylesProvider jss={mui.jss} sheetsManager={mui.sheetsManager}>
                 {children}
             </StylesProvider>
         </StyleSheetManager>,
         host
     );
 };
+
+function createHostElement(targetDoc: Document, hostId: string, styles: Partial<CSSStyleDeclaration>): HTMLElement {
+    const element = targetDoc.createElement("div");
+    element.id = hostId;
+    Object.assign(element.style, styles);
+    targetDoc.documentElement.appendChild(element);
+
+    return element;
+}
+
+function getOrCreateMuiProviders(targetDoc: Document): MuiProviders {
+    const cached = muiProvidersCache.get(targetDoc);
+    if (cached) return cached;
+
+    const head = targetDoc.head ?? targetDoc.documentElement;
+    const insertionPoint = targetDoc.createElement("style");
+    insertionPoint.setAttribute("data-autogen-forms-jss", "");
+    head.appendChild(insertionPoint);
+
+    const providers: MuiProviders = {
+        jss: create({ ...jssPreset(), insertionPoint }),
+        sheetsManager: new Map(),
+    };
+    muiProvidersCache.set(targetDoc, providers);
+
+    return providers;
+}
 
 const DEFAULT_HOST_STYLES = {
     position: "fixed",

--- a/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
@@ -80,6 +80,9 @@ function getValueAndVerifyCondition(
 ): Maybe<boolean> {
     if (rules.length !== 0) {
         return rules.some(rule => {
+            // Visibility/disabled/enabled rules evaluate against the form's base period,
+            // not the section's offset period. The related data element lives on the base
+            // period, so using the offset would look up the wrong value and break the rule.
             const dataValue = dataFormInfo.data.values.getOrEmpty(rule.relatedDataElement, {
                 orgUnitId: rule.relatedDataElement.orgUnit || dataFormInfo.orgUnitId,
                 period: dataFormInfo.period,

--- a/src/webapp/reports/autogenerated-forms/hooks/useParentDataEntryAppStyles.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useParentDataEntryAppStyles.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { getTopAccessibleWindow } from "../../../utils/topAccessibleWindow";
 
 /**
  * Injects style overrides into the topmost same-origin document so the new
@@ -8,17 +9,7 @@ import { useEffect } from "react";
  */
 export function useParentDataEntryAppStyles() {
     useEffect(() => {
-        let win: Window = window;
-        try {
-            while (win.parent && win.parent !== win) {
-                const parentDoc = win.parent.document;
-                if (!parentDoc) break;
-                win = win.parent;
-            }
-        } catch {
-            // Cross-origin ancestor — stop at the last accessible window.
-        }
-
+        const win = getTopAccessibleWindow();
         if (win === window) return;
 
         const targetDoc = win.document;

--- a/src/webapp/utils/topAccessibleWindow.ts
+++ b/src/webapp/utils/topAccessibleWindow.ts
@@ -1,0 +1,13 @@
+export function getTopAccessibleWindow(): Window {
+    let win: Window = window;
+    try {
+        while (win.parent && win.parent !== win) {
+            const parentDoc = win.parent.document;
+            if (!parentDoc) break;
+            win = win.parent;
+        }
+    } catch {
+        // Cross-origin ancestor — stop at the last accessible window.
+    }
+    return win;
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869d1mfbp

### :memo: Implementation
- [x] Replaced `useMemo` with `useEffect` + `useState` in `IframeEscapePortal`.                    
- [x] Extract `getTopAccessibleWindow()` into `src/webapp/utils/topAccessibleWindow.ts` so the parent-window resolution logic is shared instead of duplicated.           
- [x] Added a clarifying comment in `useApplyRules.getValueAndVerifyCondition` explaining why visibility/disabled/enabled rules evaluate against the form's base period rather than the section's offset period.           
         
### :art: Screenshots
<img width="1440" height="813" alt="Screenshot 2026-04-27 at 16 51 23" src="https://github.com/user-attachments/assets/ec2ae0f5-f550-4d19-8a90-82ec3540c010" />

### :fire: Notes to the tester
- Check if the validation rules popup is at the bottom right of the current viewable screen and not the entire page in the new data entry app.


#869d1mfbp