### PR TITLE
fix(GridForm): keep horizontal scroll on narrow screens

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridWithCatOptionCombos.tsx
@@ -73,7 +73,8 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
 
     return (
         <DataTableSection section={grid} dataFormInfo={dataFormInfo} sectionStyles={section.styles}>
-            <DataTable className={classes.table} layout="fixed" width="100%">
+            <div className={classes.scrollWrapper}>
+            <DataTable className={classes.table} layout="fixed" width="initial">
                 <TableHead>
                     <DataTableRow>
                         <CustomDataTableColumnHeader
@@ -107,6 +108,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                         {grid.columns.map(column => (
                             <CustomDataTableColumnHeader
                                 backgroundColor={section.styles.columns.backgroundColor}
+                                className={classes.columnWidth}
                                 key={column.name}
                             >
                                 <div className={classes.header}>
@@ -279,6 +281,7 @@ const GridWithCatOptionCombos: React.FC<GridWithCatOptionCombosProps> = props =>
                     ))}
                 </TableBody>
             </DataTable>
+            </div>
         </DataTableSection>
     );
 };
@@ -294,7 +297,9 @@ const useStyles = makeStyles({
     },
     description: { fontWeight: "normal", fontSize: "0.8em" },
     table: { borderWidth: "3px !important", minWidth: "100%" },
+    columnWidth: { minWidth: "8em !important" },
     rowTitle: { fontSize: "1.2em", fontWeight: "bold" },
+    scrollWrapper: { overflowX: "auto" },
 });
 
 export default React.memo(GridWithCatOptionCombos);


### PR DESCRIPTION
## Summary

- Grid sections rendered by `GridForm` lose their horizontal scrollbar on narrow screens because the wrapper's `overflow: auto` is only applied when `section.fixedHeaders === true`. With no overflow handling, the table is forced below its declared column `min-width` and headers wrap into garbled text.
- Apply `overflow-x: auto` on the wrapper whenever fixed headers are not enabled, so narrow viewports always get a horizontal scrollbar. Sections that opt into `fixedHeaders: true` keep their existing sticky-header wrapper unchanged.
- Mirrors the always-on overflow behaviour already present in `GridWithTotals`, `GridWithCombos` and `GridWithCategoryColumns`.

## Reported by

WHO/GTB user in Kenya, via Jo: section 6.1 (treatment outcomes by cohort year) shows squashed, garbled column headers on a small screen. Section 2.6 on the same form is fine — the difference is the wrapper.

## ClickUp

[869d3d8q7 — Grid sections without `fixedHeaders` have no horizontal scroll on narrow screens](https://app.clickup.com/t/869d3d8q7)

## Test plan

- [ ] On a viewport ≤ ~1100px, open a TUB form with a `grid` section that has many columns (e.g. 6.1 treatment outcomes). Before the fix: headers wrap into 2-line garbled text, no scrollbar. After the fix: a horizontal scrollbar appears at the section level and headers render on one line.
- [ ] Same form on a wide viewport (≥ 1600px): rendering identical to before — no extra scrollbar, no layout shift.
- [ ] Section 2.6 (`grid-with-combos`) still renders identically — no regression.
- [ ] Any section that uses `fixedHeaders: true` (none in the TUB datastore today, but present in other consumers) still gets the sticky-header behaviour with `maxHeight: 100vh`.