### PR TITLE
fix(delete-rule): scope deletions to the trigger value's period

### DIFF
--- a/src/webapp/reports/autogenerated-forms/hooks/useDeleteDataValues.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useDeleteDataValues.ts
@@ -45,7 +45,9 @@ export function useDeleteDataValues(props: UseDeleteRulesProps): UseDeleteRuleRe
                     _(dataFormInfo.data.values.store)
                         .filter(
                             dataValue =>
-                                dataValue.dataElement.code === deId && dataValue.orgUnitId === dataFormInfo.orgUnitId
+                                dataValue.dataElement.code === deId &&
+                                dataValue.orgUnitId === dataFormInfo.orgUnitId &&
+                                dataValue.period === dataValueCb.period
                         )
                         .compact()
                         .value()


### PR DESCRIPTION
## Summary

- The delete-rule sweep was matching the form's value store only on data element code and org unit, so values from referenced periods (loaded into the store for historical columns) were swept into the same DELETE batch as the current period. Toggling a trigger on period N could silently wipe a value the user had previously saved on period N-1.
- Fix scopes deletions to the trigger value's own period. Using the trigger's period (rather than the form's base period) correctly handles offset sections where trigger and targets share an offset.
- COC is intentionally left unconstrained: triggers are typically single-COC and target the full disaggregation of a DE (e.g. `TUB_agegroup_option` clearing all COCs of `TUB_newrel`).

Refs ClickUp [869da0yxb](https://app.clickup.com/t/869da0yxb).

## Test plan

Verified locally against `https://extranet.who.int/dhis2-dev` with the GTB dataset (`XGn6mrO2HU8`, OU `oofyLUJJ6Vy`):

- [x] Pre-existing 2024 value for `TUB_newinc_con` (`N9JwlMJCg2P` / `Xr12mI7VPn3`) survives a change to `TUB_screen_data_available` on period 2025. DELETE payload contains only `period:"2025"`.
- [x] Changing `TUB_agegroup_option` (single-COC trigger) still deletes `TUB_newrel` values across non-default COCs.
- [x] `yarn tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)