### PR TITLE
fix(useApplyRules): read trigger value from section's offset period

### DIFF
--- a/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useApplyRules.ts
@@ -80,12 +80,9 @@ function getValueAndVerifyCondition(
 ): Maybe<boolean> {
     if (rules.length !== 0) {
         return rules.some(rule => {
-            // Visibility/disabled/enabled rules evaluate against the form's base period,
-            // not the section's offset period. The related data element lives on the base
-            // period, so using the offset would look up the wrong value and break the rule.
             const dataValue = dataFormInfo.data.values.getOrEmpty(rule.relatedDataElement, {
                 orgUnitId: rule.relatedDataElement.orgUnit || dataFormInfo.orgUnitId,
-                period: dataFormInfo.period,
+                period: period || dataFormInfo.period,
                 categoryOptionComboId: dataFormInfo.categoryOptionComboId,
             });
 


### PR DESCRIPTION
## Task
https://app.clickup.com/t/869dbcayu

## Summary

- Fixes enable/disable/visible rules silently reading the trigger data element from the form's base period in sections that declare `periods.type === "section-offset"`.
- Both the trigger and the dependent live on the offset period in those sections, so the lookup must use the section-aware `period` argument that is already passed in (the same one `evaluateTotalRule` uses).
- One-line change: `period: dataFormInfo.period` → `period: period || dataFormInfo.period`. Removed the stale comment that argued for the buggy behaviour.

## Context

- Section 19.7 (`+1` offset): 19.7.4 = Yes on the offset period, but the rule reads the base period where the trigger is empty/stale → 19.7.5 stays disabled. Symmetrically, Kenya 19.7.7 stayed disabled and Ethiopia 19.7.7 was enabled when it should not have been.
- Same root cause for sections 6.3.2 / 6.5.2 / 8.4.2 (which have `-1` offset).

Origin of the bug: commit 07670dc pinned this branch to `dataFormInfo.period` after #177 had added the `period` plumbing for offset sections. This restores the intended behaviour.

## Test plan

- [x] Reproduced bug locally against PROD backend on Qatar (`jCtFxm8aADJ`), period 2025: 19.7.4 = Yes, 19.7.5 disabled.
- [x] After fix, 19.7.5 becomes enabled with no other state change; 19.7.7 correctly stays disabled because 19.7.6 was not answered for 2026.
- [x] Cross-check Kenya (`HfVjCurKxh2`) and Ethiopia (`zEYrsiNUGIo`) for 19.7.7.
- [x] Cross-check at least one `-1` offset section (6.3.2 / 6.5.2 / 8.4.2) to confirm same fix covers Jo's second report.
- [ ] Regression check: rules in non-offset sections still evaluate correctly (no `period` arg → falls back to `dataFormInfo.period`).