### PR TITLE
[fix]: Replace invalid-XML control chars from data values on save

### DIFF
--- a/src/data/common/Dhis2DataValueRepository.ts
+++ b/src/data/common/Dhis2DataValueRepository.ts
@@ -14,7 +14,7 @@ import {
 import { DataValueRepository, DataElementRefType } from "../../domain/common/repositories/DataValueRepository";
 import { D2Api, DataValueSetsDataValue } from "../../types/d2-api";
 import { promiseMap } from "../../utils/promises";
-import { stripInvalidXmlChars } from "../../utils/string";
+import { replaceInvalidXmlChars } from "../../utils/string";
 import { assertUnreachable, Maybe } from "../../utils/ts-utils";
 import { Dhis2DataElement } from "./Dhis2DataElement";
 
@@ -473,11 +473,11 @@ export class Dhis2DataValueRepository implements DataValueRepository {
             case "NUMBER":
                 return (dataValue.isMultiple ? dataValue.values.join("; ") : dataValue.value) || "";
             case "TEXT":
-                return stripInvalidXmlChars(
+                return replaceInvalidXmlChars(
                     (dataValue.isMultiple ? dataValue.values.join("; ") : dataValue.value) || ""
                 );
             case "MULTI_TEXT":
-                return dataValue.values.map(value => stripInvalidXmlChars(value)).join(MULTI_TEXT_SEPARATOR);
+                return dataValue.values.map(value => replaceInvalidXmlChars(value)).join(MULTI_TEXT_SEPARATOR);
             case "FILE":
                 return dataValue.file?.id || "";
             case "PERCENTAGE":

--- a/src/data/common/Dhis2DataValueRepository.ts
+++ b/src/data/common/Dhis2DataValueRepository.ts
@@ -14,6 +14,7 @@ import {
 import { DataValueRepository, DataElementRefType } from "../../domain/common/repositories/DataValueRepository";
 import { D2Api, DataValueSetsDataValue } from "../../types/d2-api";
 import { promiseMap } from "../../utils/promises";
+import { stripInvalidXmlChars } from "../../utils/string";
 import { assertUnreachable, Maybe } from "../../utils/ts-utils";
 import { Dhis2DataElement } from "./Dhis2DataElement";
 
@@ -470,10 +471,13 @@ export class Dhis2DataValueRepository implements DataValueRepository {
                     ? "false"
                     : "";
             case "NUMBER":
-            case "TEXT":
                 return (dataValue.isMultiple ? dataValue.values.join("; ") : dataValue.value) || "";
+            case "TEXT":
+                return stripInvalidXmlChars(
+                    (dataValue.isMultiple ? dataValue.values.join("; ") : dataValue.value) || ""
+                );
             case "MULTI_TEXT":
-                return dataValue.values.join(MULTI_TEXT_SEPARATOR);
+                return dataValue.values.map(value => stripInvalidXmlChars(value)).join(MULTI_TEXT_SEPARATOR);
             case "FILE":
                 return dataValue.file?.id || "";
             case "PERCENTAGE":

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -6,3 +6,12 @@ export function removePrefixFromWords(text: string, prefix: string): string {
     const regex = new RegExp(`\\b${escapedPrefix}`, "g");
     return text.replace(regex, "").trim();
 }
+
+// Strips C0 control characters that are invalid in XML 1.0 (and therefore in
+// .xlsx exports). Keeps \t, \n, \r — the three whitespace controls XML allows.
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+export function stripInvalidXmlChars(text: string): string {
+    return text.replace(INVALID_XML_CHARS_RE, "");
+}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -7,11 +7,11 @@ export function removePrefixFromWords(text: string, prefix: string): string {
     return text.replace(regex, "").trim();
 }
 
-// Strips C0 control characters that are invalid in XML 1.0 (and therefore in
-// .xlsx exports). Keeps \t, \n, \r — the three whitespace controls XML allows.
+// Replaces C0 control chars invalid in XML 1.0 with a space.
+// Preserves \t, \n, \r (the only whitespace controls XML 1.0 allows).
 // eslint-disable-next-line no-control-regex
 const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 
-export function stripInvalidXmlChars(text: string): string {
+export function replaceInvalidXmlChars(text: string): string {
     return text.replace(INVALID_XML_CHARS_RE, " ");
 }

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -13,5 +13,5 @@ export function removePrefixFromWords(text: string, prefix: string): string {
 const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 
 export function stripInvalidXmlChars(text: string): string {
-    return text.replace(INVALID_XML_CHARS_RE, "");
+    return text.replace(INVALID_XML_CHARS_RE, " ");
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dbc90g

### :memo: Implementation
The client report surfaced a Bulk Load Excel export that failed to open in MS Excel (`error237400_01.xml`: "Illegal xml character. Line 395, column 174" in `/xl/sharedStrings.xml`). 
Root cause: an invisible **vertical tab (`\x0B`)** had been entered into a TEXT data value. XLSX is XML 1.0; XML 1.0 forbids most C0 control characters, so Excel rejected the file. LibreOffice silently strips these on save, which is why a LibreOffice round-trip "fixed" the file.

This PR sanitizes data values at the save boundary in autogen-forms so the same characters never get persisted again:

**Out of scope (sibling task in Bulk Load):** historical bad values already in DHIS2 and values entered through other paths (DHIS2 web data entry, imports) still need a defensive strip on the Bulk Load xlsx export side. [Bulk Load PR 399](https://github.com/EyeSeeTea/Bulk-Load/pull/399)


  #869dbc90g
