### PR TITLE
fix: 2.42 support - removal of userCredentials

### DIFF
--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -88,10 +88,8 @@ export class Dhis2ConfigRepository implements ConfigRepository {
                         path: true,
                         level: true,
                     },
-                    userCredentials: {
-                        username: true,
-                        userRoles: { id: true, name: true },
-                    },
+                    username: true,
+                    userRoles: { id: true, name: true },
                     userGroups: { id: true, name: true },
                 },
             })
@@ -105,7 +103,10 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             orgUnits: d2User.dataViewOrganisationUnits,
             userGroups: d2User.userGroups,
             canCreateConstant: canCreateConstant,
-            ...d2User.userCredentials,
+            // @ts-expect-error - upgrade d2-api for up-to-date types
+            username: d2User.username,
+            // @ts-expect-error - upgrade d2-api for up-to-date types
+            userRoles: d2User.userRoles,
         };
     }
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dd3hj0

### :memo: Implementation

- Under DHIS 2.42 the `userCredentials` property was removed. Its fields (`username`, `userRoles`) are now included on the top-level User object. This PR fetches and reads them from the root.
- This PR no longer supports instances where `username` and `userRoles` are only available under `userCredentials`. Versions equal or greater than 2.40 are supported.
- Mirrors the equivalent fix applied to data-quality-extended-app in https://github.com/EyeSeeTea/data-quality-extended-app/pull/87.

**Alternatives explored:**
- Considered fetching the props from both top-level User and `userCredentials` for backwards compatibility, but discarded to avoid duplicated fields in 2.40/2.41 responses (serialization/parse overhead with many roles/authorities).
- Tried upgrading d2-api to a version with proper typings, but unrelated typing errors surfaced. Kept this PR focused; `@ts-expect-error` comments are temporary until the d2-api upgrade.

### :art: Screenshots

### :fire: Notes to the tester

- Verify the app initializes on a DHIS2 2.42 instance.
- Verify it still works on 2.40 / 2.41.