### PR TITLE
fix(data): include required dataset fields in install custom form metadata POST

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "prepare": "husky install"
     },
     "appVersions": {
-        "configurator": "1.5.3"
+        "configurator": "1.6.0"
     },
     "devDependencies": {
         "@babel/core": "7.16.0",


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Related to v1.6.0 release

### :memo: Implementation

- Fixes a 409 error when installing the custom form by including all required dataset fields in the metadata POST payload.
- Bumps the configurator `appVersions` to 1.6.0.

### :art: Screenshots

N/A

### :fire: Notes to the tester

Deploy the custom form from the configurator and verify no 409 error is returned.