### PR TITLE
[feature]: Keep numeric inputs consistent across browsers (Firefox space bug)

### DIFF
--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -15,3 +15,17 @@ const INVALID_XML_CHARS_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
 export function replaceInvalidXmlChars(text: string): string {
     return text.replace(INVALID_XML_CHARS_RE, " ");
 }
+
+// Strips every character that cannot appear in a number, keeping only digits,
+// decimal points and minus signs.
+const NON_NUMERIC_CHARS_RE = /[^0-9.-]/g;
+
+export function sanitizeNumericInput(input: string): string {
+    return input.replace(NON_NUMERIC_CHARS_RE, "");
+}
+
+// True when the (already sanitized) value is a non-empty, well-formed number.
+// Rejects partial inputs that survive sanitization, e.g. "1.2.3", "5-", ".".
+export function isValidNumber(value: string): boolean {
+    return value !== "" && !Number.isNaN(Number(value));
+}

--- a/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/AutogeneratedForm.tsx
@@ -249,31 +249,12 @@ function useDataFormInfo() {
     }, [dataForm, orgUnits, compositionRoot.dataForms, dataSetId, orgUnitId, period]);
 
     React.useEffect(() => {
-        // Hiding arrows for input of type number
-        // adding directly to css works in dev, but not in data entry.
-        const css =
-                'input::-webkit-outer-spin-button,input::-webkit-inner-spin-button {-webkit-appearance: none !important; margin: 0; } input[type=number] { -moz-appearance: textfield !important; }[data-test="dhis2-uicore-layer"] {z-index: 10 !important;}',
+        const css = '[data-test="dhis2-uicore-layer"] {z-index: 10 !important;}',
             head = document.head || document.getElementsByTagName("head")[0],
             style = document.createElement("style");
-        style.setAttribute("id", "disabled-arrows-css");
+        style.setAttribute("id", "dhis2-layer-zindex-css");
         style.appendChild(document.createTextNode(css));
         head.appendChild(style);
-
-        function disableScrollInputs() {
-            if (
-                window.document.activeElement instanceof HTMLInputElement &&
-                window.document.activeElement.type === "number" &&
-                window.document.activeElement.classList.contains("noscroll")
-            ) {
-                window.document.activeElement.blur();
-            }
-        }
-
-        document.addEventListener("wheel", disableScrollInputs);
-
-        return () => {
-            document.removeEventListener("wheel", disableScrollInputs);
-        };
     }, []);
 
     useEffect(() => {

--- a/src/webapp/reports/autogenerated-forms/hooks/useNumericInputState.ts
+++ b/src/webapp/reports/autogenerated-forms/hooks/useNumericInputState.ts
@@ -1,0 +1,59 @@
+import React, { useCallback, useEffect } from "react";
+import { isValidNumber, sanitizeNumericInput } from "../../../../utils/string";
+import { DataValue, DataValueNumberSingle, DataValuePercentage } from "../../../../domain/common/entities/DataValue";
+
+/**
+ * Input state for numeric text widgets, behaving the same across browsers.
+ *
+ * - `onChange` filters non-numeric characters live via {@link sanitizeNumericInput},
+ *   ignoring any edit that would blank an already-saved value.
+ * - `onBlur` commits through `onValueChange` when the value is empty (a clear) or passes
+ *   `isValid` (defaults to {@link isValidNumber}); otherwise it sets `isInvalid` and keeps
+ *   the value on screen unsaved, so an existing value is never overwritten with bad data.
+ */
+export function useNumericInputState(
+    dataValue: DataValueNumberSingle | DataValuePercentage,
+    onValueChange: (dataValue: DataValue) => void,
+    isValid: (value: string) => boolean = isValidNumber
+) {
+    const [value, setValue] = React.useState(dataValue.value);
+    const [isInvalid, setIsInvalid] = React.useState(false);
+
+    useEffect(() => setValue(dataValue.value), [dataValue]);
+
+    const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const raw = e.target.value;
+        const filtered = sanitizeNumericInput(raw);
+        if (filtered === "" && raw !== "") return;
+        setValue(filtered);
+    }, []);
+
+    const onCommit = useCallback(
+        (newValue: string) => {
+            if (newValue === "" || isValid(newValue)) {
+                setIsInvalid(false);
+                onValueChange({ ...dataValue, value: newValue });
+            } else {
+                setIsInvalid(true);
+            }
+        },
+        [dataValue, onValueChange, isValid]
+    );
+
+    const onBlur = useCallback(
+        (e: React.FocusEvent<HTMLInputElement>) => {
+            const newValue = e.target.value;
+            if (newValue === dataValue.value) return;
+
+            if (newValue === "" || isValid(newValue)) {
+                setIsInvalid(false);
+                onCommit(newValue);
+            } else {
+                setIsInvalid(true);
+            }
+        },
+        [dataValue, onCommit, isValid]
+    );
+
+    return { value, isInvalid, onChange, onBlur };
+}

--- a/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import styled from "styled-components";
-// @ts-ignore
-
 import { WidgetFeedback } from "../WidgetFeedback";
 import { DataValueNumberSingle } from "../../../../domain/common/entities/DataValue";
 import { WidgetProps } from "./WidgetBase";
-import { useInputState } from "../hooks/useInputState";
+import { useNumericInputState } from "../hooks/useNumericInputState";
 
 export interface NumberWidgetProps extends WidgetProps {
     dataValue: DataValueNumberSingle;
@@ -14,41 +12,14 @@ export interface NumberWidgetProps extends WidgetProps {
 const NumberWidget: React.FC<NumberWidgetProps> = props => {
     const { onValueChange, dataValue, disabled } = props;
 
-    const { value, onChange } = useInputState(dataValue.value);
-
-    const notifyChange = React.useCallback(
-        ({ value: newValue }: { value: string }) => {
-            if (dataValue.value !== newValue) {
-                onValueChange({ ...dataValue, value: newValue });
-            }
-        },
-        [onValueChange, dataValue]
-    );
-
-    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-            e.preventDefault();
-        }
-    };
+    const { value, isInvalid, onChange, onBlur } = useNumericInputState(dataValue, onValueChange);
 
     return (
-        <WidgetFeedback state={props.state}>
+        <WidgetFeedback state={isInvalid ? "saveError" : props.state}>
             {disabled ? (
-                <CustomInput
-                    disabled
-                    type="number"
-                    onBlur={e => notifyChange({ value: e.target.value })}
-                    value={dataValue.value}
-                />
+                <CustomInput disabled type="text" inputMode="decimal" value={dataValue.value} />
             ) : (
-                <CustomInput
-                    type="number"
-                    onBlur={e => notifyChange({ value: e.target.value })}
-                    value={value}
-                    onChange={onChange}
-                    onKeyDown={onKeyDown}
-                    className="noscroll"
-                />
+                <CustomInput type="text" inputMode="decimal" onBlur={onBlur} value={value} onChange={onChange} />
             )}
         </WidgetFeedback>
     );

--- a/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
@@ -33,8 +33,8 @@ export const CustomInput = styled.input`
     user-select: text;
     color: rgb(33, 41, 52);
     background-color: white;
-    padding: 12px 11px 10px;
-    min-height: 48px;
+    padding: 12px 11px 10px !important;
+    min-height: 40px;
     outline: 0px;
     border: 1px solid rgb(160, 173, 186);
     border-radius: 3px;

--- a/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/NumberWidget.tsx
@@ -34,6 +34,7 @@ export const CustomInput = styled.input`
     color: rgb(33, 41, 52);
     background-color: white;
     padding: 12px 11px 10px;
+    min-height: 48px;
     outline: 0px;
     border: 1px solid rgb(160, 173, 186);
     border-radius: 3px;

--- a/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import styled from "styled-components";
 import { WidgetFeedback } from "../WidgetFeedback";
 import { DataValuePercentage } from "../../../../domain/common/entities/DataValue";
 import { WidgetProps } from "./WidgetBase";
 import { useNumericInputState } from "../hooks/useNumericInputState";
 import { isValidNumber } from "../../../../utils/string";
+import { CustomInput } from "./NumberWidget";
 
 export interface PercentageWidgetProps extends WidgetProps {
     dataValue: DataValuePercentage;
@@ -25,30 +25,6 @@ const PercentageWidget: React.FC<PercentageWidgetProps> = props => {
         </WidgetFeedback>
     );
 };
-
-const CustomInput = styled.input`
-    width: 100%;
-    box-sizing: border-box;
-    font-size: 14px;
-    line-height: 16px;
-    user-select: text;
-    color: rgb(33, 41, 52);
-    background-color: white;
-    padding: 12px 11px 10px;
-    min-height: 48px;
-    outline: 0px;
-    border: 1px solid rgb(160, 173, 186);
-    border-radius: 3px;
-    box-shadow: rgba(48, 54, 60, 0.1) 0px 1px 2px 0px inset;
-    text-overflow: ellipsis;
-
-    &:disabled {
-        background-color: rgb(248, 249, 250);
-        border-color: rgb(160, 173, 186);
-        color: rgb(110, 122, 138);
-        cursor: not-allowed;
-    }
-`;
 
 export default React.memo(PercentageWidget);
 

--- a/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
@@ -35,6 +35,7 @@ const CustomInput = styled.input`
     color: rgb(33, 41, 52);
     background-color: white;
     padding: 12px 11px 10px;
+    min-height: 48px;
     outline: 0px;
     border: 1px solid rgb(160, 173, 186);
     border-radius: 3px;

--- a/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
+++ b/src/webapp/reports/autogenerated-forms/widgets/PercentageWidget.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import { WidgetFeedback } from "../WidgetFeedback";
 import { DataValuePercentage } from "../../../../domain/common/entities/DataValue";
 import { WidgetProps } from "./WidgetBase";
-import { useInputState } from "../hooks/useInputState";
+import { useNumericInputState } from "../hooks/useNumericInputState";
+import { isValidNumber } from "../../../../utils/string";
 
 export interface PercentageWidgetProps extends WidgetProps {
     dataValue: DataValuePercentage;
@@ -12,39 +13,14 @@ export interface PercentageWidgetProps extends WidgetProps {
 const PercentageWidget: React.FC<PercentageWidgetProps> = props => {
     const { onValueChange, dataValue, disabled } = props;
 
-    const { value, onChange } = useInputState(dataValue.value);
-
-    const notifyChange = React.useCallback(
-        ({ value: newValue }: { value: string }) => {
-            const inputValue = parseFloat(newValue);
-
-            if (dataValue.value !== newValue) {
-                if (inputValue < 0 || inputValue > 100) {
-                    alert("Value must be a percentage (between 0 and 100)");
-                } else {
-                    onValueChange({ ...dataValue, value: inputValue.toString() });
-                }
-            }
-        },
-        [dataValue, onValueChange]
-    );
+    const { isInvalid, value, onBlur, onChange } = useNumericInputState(dataValue, onValueChange, isValidPercentage);
 
     return (
-        <WidgetFeedback state={props.state}>
+        <WidgetFeedback state={isInvalid ? "saveError" : props.state}>
             {disabled ? (
-                <CustomInput
-                    disabled
-                    type="number"
-                    onBlur={e => notifyChange({ value: e.target.value })}
-                    value={dataValue.value}
-                />
+                <CustomInput disabled type="text" inputMode="decimal" value={dataValue.value} />
             ) : (
-                <CustomInput
-                    type="number"
-                    onBlur={e => notifyChange({ value: e.target.value })}
-                    value={value}
-                    onChange={onChange}
-                />
+                <CustomInput type="text" inputMode="decimal" onBlur={onBlur} value={value} onChange={onChange} />
             )}
         </WidgetFeedback>
     );
@@ -74,3 +50,6 @@ const CustomInput = styled.input`
 `;
 
 export default React.memo(PercentageWidget);
+
+const isValidPercentage = (value: string): boolean =>
+    isValidNumber(value) && Number(value) >= 0 && Number(value) <= 100;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869djz6bn

### :memo: Implementation
`<input type="number">` handled "bad input" inconsistently across browsers: typing a space as a thousands separator (e.g. `1 000`) was stripped to `1000` in Chrome but blanked the whole value in Firefox, silently losing data on save.

Switched `NumberWidget` and `PercentageWidget` to `type="text"` + `inputMode="decimal"` and centralised the behaviour in a new `useNumericInputState` hook so both widgets behave identically on every browser.

### :art: Screenshots

### :fire: Notes to the tester

#869djz6bn