### PR TITLE
[fix]: Restore grid view layout broken by layout="fixed"

### DIFF
--- a/src/webapp/reports/autogenerated-forms/GridForm.tsx
+++ b/src/webapp/reports/autogenerated-forms/GridForm.tsx
@@ -51,7 +51,7 @@ const GridForm: React.FC<GridFormProps> = props => {
     const fixColumns = section.fixedHeaders;
     const fixRows = section.fixedRowNames;
     const mainContentStyles = fixColumns ? fixHeaderClasses.fixedHeaders : {};
-    const firstColumnWidth = section.firstColumnConfig?.width || "auto";
+    const firstColumnWidth = section.firstColumnConfig?.width || 800;
 
     const NonDirectionalIndicators = grid.nonDirectionalIndicators.map(indicator => (
         <RowIndicatorItem
@@ -71,7 +71,7 @@ const GridForm: React.FC<GridFormProps> = props => {
             )}
 
             <div ref={wrapper2Ref} style={mainContentStyles}>
-                <DataTable className={classes.table} layout="fixed">
+                <DataTable className={classes.table}>
                     <TableHead className={fixColumns ? classes.tableHeader : ""}>
                         <DataTableRow>
                             {grid.hasGroups && (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [#869dvhggv](https://app.clickup.com/t/4528615/869dvhggv)
-   **Regression from:** #184 (`fix/grid-form-narrow-screen-overflow`)

### :memo: Implementation
The `grid` view type (e.g. in the NTD form) rendered distorted: all data columns were crammed into the container width, headers overlapped, and row heights blew up.

Root cause is commit `47eb7dd` ("feat: fix overflowing sections", PR #184), which added `layout="fixed"` to `GridForm`. With `table-layout: fixed` the browser ignores the `min-width: 14.25em` on the data-column headers and
squeezes every column to fit the viewport, instead of letting the table size to content and scroll horizontally (grid forms are built to overflow.

A second latent bug: the same commit changed the first-column width default from `800` to `"auto"`. Since `firstColumnConfig.width` is typed `number`, and it is consumed as `` width={`${firstColumnWidth}px`} ``, the new default
rendered as the invalid CSS value `"autopx"`.

The follow-up commit `2dd8ab1` (Miquel Adell) fixed exactly this column-compression symptom for `GridWithCatOptionCombos` (overflow wrapper + min-width + `width="initial"`) but never applied the correction to
`GridForm`, leaving the plain grid view broken.

This PR reverts only the two distortion-causing changes in `GridForm.tsx`:
-   Remove `layout="fixed"` from the `DataTable` → auto layout honors the column `min-width` and the table scrolls horizontally again.
-   Restore the `firstColumnWidth` default to `800` (fixes the `"autopx"` value).

The period-column width bump (`50px → 120px`) from #184 is kept — it is a genuine improvement and plays no part in the distortion. The overflow fixes for `TableForm` and `GridWithCatOptionCombos` are left untouched.

### :art: Screenshots
Before: 

https://github.com/user-attachments/assets/1f85f834-6938-4523-995f-bca62f141492


After:

https://github.com/user-attachments/assets/6ad48dc7-f28e-4f0a-9083-422a16c30a85


### :fire: Notes to the tester

##869dvhggv